### PR TITLE
Changed "Quote currency" to "quote unit"

### DIFF
--- a/specs/0001-market-framework.md
+++ b/specs/0001-market-framework.md
@@ -45,7 +45,7 @@ Data:
 
 Params:
   - **Tick size** (size of an increment in price in terms of the quote unit)
-  - **Decimal places**, number of decimals places for price quotes, e.g. if quote currency is USD and decimal places is 2 then prices are quoted in integer numbers of cents.
+  - **Decimal places**, number of decimals places for quotes unit, e.g. if quote unit is USD and decimal places is 2 then prices are quoted in integer numbers of cents.
 
 ## Tradable instrument
 

--- a/specs/0001-market-framework.md
+++ b/specs/0001-market-framework.md
@@ -44,7 +44,7 @@ Data:
 ### Trading mode - continuous trading
 
 Params:
-  - **Tick size** (size of an increment in price in terms of the quote currency)
+  - **Tick size** (size of an increment in price in terms of the quote unit)
   - **Decimal places**, number of decimals places for price quotes, e.g. if quote currency is USD and decimal places is 2 then prices are quoted in integer numbers of cents.
 
 ## Tradable instrument


### PR DESCRIPTION
Before:
  - **Tick size** (size of an increment in price in terms of the quote currency)
After: 
  - **Tick size** (size of an increment in price in terms of the quote unit)

This is referred to as "Price / quote unit" in the instrument section, This could also be changed simply to "Quote unit"