### PR TITLE
Make it clearer that Filled+Expired GTT orders are not possible

### DIFF
--- a/specs/0024-order-status.md
+++ b/specs/0024-order-status.md
@@ -43,7 +43,6 @@ For the definition of each Time In Force option, see [the Order Types spec](./00
 |      GTC      |   Yes   |         No        |         No        |      Filled      |
 
 ## Good ’Til Time
-Note: The last row in the table below is added for clarity rather than being a legitimate situation. If the order filled, it is marked as FILLED and it is removed from the book, so it can’t expire after filling. 
 
 | Time In Force | Filled  | Expired | Cancelled by user | Stopped by system | Resulting status |
 |---------------|---------|---------|-------------------|-------------------|------------------|
@@ -56,7 +55,9 @@ Note: The last row in the table below is added for clarity rather than being a l
 |      GTT      | Partial |    No   |        Yes        |         No        |     Cancelled    |
 |      GTT      | Partial |    No   |         No        |        Yes        |      Stopped     |
 |      GTT      |   Yes   |    No   |         No        |         No        |      Filled      |
-|      GTT      |   Yes   |   Yes   |         No        |         No        |      Filled      |
+|      GTT      |   Yes   |   Yes   |         No        |         No        | not possible (see note) |
+
+Note: The last row in the table above is added for clarity. If the order was filled, it is marked as Filled and it is removed from the book, so it can't expire after being filled.
 
 ## Wash trading
 If an order would be filled or partially filled with an existing order from the same traderID, the order is rejected. Any existing fills that happen before the wash trade is identified will be kept.


### PR DESCRIPTION
This PR changes "Filled" to "not possible (see note)" for GTT Expired+Filled orders, since that is not a possible combination.

See also https://github.com/vegaprotocol/vega/issues/1859#issuecomment-654699366