### PR TITLE
Updated wash trade statuses

### DIFF
--- a/specs/0024-order-status.md
+++ b/specs/0024-order-status.md
@@ -64,6 +64,6 @@ If an order would be filled or partially filled with an existing order from the 
 
 | Filled State | Resulting status | Reason |
 |--------------|------------------|--------|
-|   Unfilled   |     Rejected     | Order would match with an order with the same partyID |
-|   Partially  |     Rejected     | Order has been partially filled but the next partial fill would be with an order with the same partyID |
+|   Unfilled   |     Stopped     | Order would match with an order with the same partyID |
+|   Partially  |     Partially Filled     | Order has been partially filled but the next partial fill would be with an order with the same partyID |
 


### PR DESCRIPTION
The status values for wash trades were set to REJECTED but we felt that did not reflect what had happened to the order. REJECTED implies the order was invalid and should not go near the order book. I have updated the statuses to be STOPPED in the case a wash trade is found as the first match and PARTIALLY FILLED in the case some of the order can be filled with valid trades.