### PR TITLE
Add max deposit size

### DIFF
--- a/specs/0031-ethereum-bridge-spec.md
+++ b/specs/0031-ethereum-bridge-spec.md
@@ -120,3 +120,9 @@ Blacklisting is simply removing an asset from the whitelist
 *  A valid multisig bundle can be passed to the setDepositMinimum function to successfully set a deposit minimum for a given asset
 *  an invalid multisig bundle is rejected by the setDepositMinimum function
 
+## Set deposit Maximum
+*  A bridge smart contract for Ethereum is deployed to Ethereum Testnet (Ropsten)
+*  A bridge smart contract for ERC20 is deployed to Ethereum Testnet (Ropsten)
+*  A valid multisig bundle can be passed to the setDepositMinimum function to successfully set a deposit minimum for a given asset
+*  an invalid multisig bundle is rejected by the setDepositMinimum function
+


### PR DESCRIPTION
Add a new acceptance criteria for max deposit size, required for 🤠 net

NOTE: This is a *draft* because the requirement for 🤠 is not yet well understood. It will probably be a *lifetime* max. Or total monetary value. We are unsure. But it'll be *something*, to be decided by @barnabee.

Spec call to be arranged by @tamlyn10 for @C0deMunk33 / @barnabee etc