### PR TITLE
Prevent GFN market order (#390)

### DIFF
--- a/specs/0014-order-types.md
+++ b/specs/0014-order-types.md
@@ -57,7 +57,7 @@ Notes on scope of current version of this spec:
 | -------------- |:---:|:---:|:---:|:---:|:---:|:---:|
 | Limit          | Y   | Y   | Y   | Y   | N   | Y   |
 | Pegged         | Y   | Y   | Y   | Y   | N   | Y   |
-| Market         | N   | N   | Y   | Y   | N   | Y   |
+| Market         | N   | N   | Y   | Y   | N   | N   |
 
 
 ##### Auction


### PR DESCRIPTION
The spec originally said that it was possible to send the TIF flag of GFN when sending a MARKET order. This was incorrect as the matching engine would not know how to handle the MARKET order without either IOC or FOK.
