### PR TITLE
Shift peg prices when outside the valid price range

### DIFF
--- a/specs/0038-liquidity-provision-order-type.md
+++ b/specs/0038-liquidity-provision-order-type.md
@@ -83,6 +83,7 @@ Given the price peg information (`peg-reference`, `number-of-units-from-referenc
 ``` volume = ceiling(liquidity_obligation x liquidity-normalised-proportion / probability_of_trading / price)```. 
 
 where `liquidity_obligation` is calculated as defined in the [market making mechanics spec](./0044-lp-mechanics.md) and `price` is the price level at which the `volume` will be placed.
+Note: if the resulting price for any of the entries in the buy / sell shape is outside the valid price range as provided by the price monitoring module it should get shifted to the valid price that's furthest away from the mid for the given order-book side.
 
 ```
 Example: 

--- a/specs/0038-liquidity-provision-order-type.md
+++ b/specs/0038-liquidity-provision-order-type.md
@@ -83,7 +83,7 @@ Given the price peg information (`peg-reference`, `number-of-units-from-referenc
 ``` volume = ceiling(liquidity_obligation x liquidity-normalised-proportion / probability_of_trading / price)```. 
 
 where `liquidity_obligation` is calculated as defined in the [market making mechanics spec](./0044-lp-mechanics.md) and `price` is the price level at which the `volume` will be placed.
-Note: if the resulting price for any of the entries in the buy / sell shape is outside the valid price range as provided by the price monitoring module it should get shifted to the valid price that's furthest away from the mid for the given order-book side.
+Note: if the resulting price for any of the entries in the buy / sell shape is outside the valid price range as provided by the price monitoring module (the min/max price that would not trigger the price monitoring auction per triggers configured in the market, see [price monitoring](./0032-price-monitoring.md#view-from-quant-library-side) spec for details) it should get shifted to the valid price that's furthest away from the mid for the given order-book side.
 
 ```
 Example: 


### PR DESCRIPTION
Add the bit saying that if the price for a given peg is outside the valid price range as implied by the price monitoring module then it should get shifted "in" so that it's at the last valid tick for that side of the order book.

Closes #412 