### PR TITLE
Add new pullrequests to protocol design project board

### DIFF
--- a/.github/workflows/add_research_PR_to_board.yml
+++ b/.github/workflows/add_research_PR_to_board.yml
@@ -1,0 +1,17 @@
+name: Auto Assign New Pull Requests to Project(s)
+
+on:
+  pull_requests:
+    types: [opened]
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Add new pull requests to org Protocol Design project
+    steps:
+      - uses: alex-page/github-project-automation-plus@50502d399cbb98cefe7ce1f99f93f78c6756562e
+        with:
+          project: Protocol Design
+          column: In progress
+          repo-token: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+

--- a/.github/workflows/add_research_PR_to_board.yml
+++ b/.github/workflows/add_research_PR_to_board.yml
@@ -1,7 +1,7 @@
 name: Auto Assign New Pull Requests to Project(s)
 
 on:
-  pull_requests:
+  pull_request:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
Add new action to move any PRs created for the specs internal repo to the in progress column on the protocol design project board. Its a separate action to the issues in order to be able to turn off in the Github UI if it becomes too noisy on the project board. They may want to be merged to a single action at a later date. 
