### PR TITLE
Target stake and auction extension edit

### DIFF
--- a/protocol/0021-market-data-spec.md
+++ b/protocol/0021-market-data-spec.md
@@ -23,20 +23,34 @@ Due to supporting dynamic orders such as pegged orders the main market data fiel
 
 ## Market data
 
-### Continuous trading (order book)
+List of market data fields to be available via the API. All these values can be empty/nothing if there is insufficient relevant data.
 
-All these values can be empty/nothing if there is insufficient relevant data.
-
-  - **Best bid price:** the highest price level on an order book for persistent, non pegged buy orders.
-  - **Best bid volume:** the aggregated volume being bid at the _best bid price_ excluding pegged orders.
-  - **Best offer price:** the lowest price level on an order book for persistent, non pegged offer orders.
-  - **Best offer volume:** the aggregated volume being offered at the _best offer price_ excluding pegged orders.
+  - **Market** market ID.
+  - **Timestamp** current time used by the market in nanoseconds since the epoch.
+  - **Market trading mode** the current trading mode of the market.
+  - **Best bid price:** the highest bid price level on the order book.
+  - **Best bid volume:** the aggregated volume being bid at the _best bid price_.
+  - **Best offer price:** the lowest offer price level on the order book.
+  - **Best offer volume:** the aggregated volume being offered at the _best offer price_.
   - **Mid price:** the arithmetic average of the _best bid price_ and _best offer price_.
   - **Mark price:** the current mark price as calculated by the selected mark price methodology.
   - **Open interest:** the sum of the size of all positions greater than 0. This needs take into account Position Decimal Places, unless raw ints are being used as for prices, in which case, clients will need to take into account the position d.p.s.
-  - **Best static bid price:** the highest price level on the order book for non-dynamic buy orders.
-  - **Best static offer price:** the lowest price level on an order book for non-dynamic offer orders.
+  - **Best static bid price:** the highest bid price level on an order book for persistent, non pegged buy orders.
+  - **Best static bid volume:** the aggregate volume at the _best static bid price_ excluding pegged orders
+  - **Best static offer price:** the lowest offer price level on an order book for persistent, non pegged sell orders.
+  - **Best static offer volume:** the aggregate volume at the _best static offer price_ excluding pegged orders.
   - **Static mid price:** the arithmetic average of the _best static bid price_ and _best static offer price_.
+  - **Indicative price** indicative auction uncrossing price.
+  - **Indicative volume** indicative auction uncrossing volume.
+  - **Auction start** start time of the current auction.
+  - **Auction end** end time of the current auction (if auction exit trigger is time-based).
+  - **Auction trigger** trigger of the current auction.
+  - **Auction extension trigger** trigger of the extension of the current auction.
+  - **Target stake** market's target stake based on current open interest when market is in default trading mode and a theoretical value based on auction's indicative volume when market is in auction mode.
+  - **Supplied stake** market's supplied stake.
+  - **Price monitoring bounds** one or more price monitoring bounds for the current timestamp.
+  - **Market value proxy** market value proxy for liquidity provision reward calculation purposes.
+  - **Liquidity provider fee share** share of the accrued fees each liquidity provider is eligible to.
 
 # Pseudo-code / Examples
 

--- a/protocol/0026-auctions.md
+++ b/protocol/0026-auctions.md
@@ -106,8 +106,7 @@ Auction periods may be ended with an uncrossing and the creation of any resultin
 - the auction call period end time being reached (if such a time is set); or 
 - other functionality (related to the type of auction period) that triggers the end of auction.
 
-Auction periods do not end if the resulting state would immediately cause another auction to occur. Instead an _extension period_ is added to the auction of the relevant type. For example, if a liquidity monitoring auction would be triggered at the end of an opening auction, then the auction continues and the market is in a "liquidity monitoring extension [auction]".
-
+Auction periods do not end if the resulting state would immediately cause another auction to occur. Instead the current auction gets extended. For example, if a liquidity monitoring auction would be triggered at the end of an opening auction, then the opening auction continues and the _auction extension trigger_ field in the [market data API](./0021-market-data-spec.md) is updated to account for the fact that the opening auction has been extended due to insufficent liquidity.
 
 ### Ending when a market is going to enter Trading Terminated status
 

--- a/protocol/0041-target-stake.md
+++ b/protocol/0041-target-stake.md
@@ -48,7 +48,9 @@ Note that the units of `target_stake` are the settlement currency of the market 
 Example 3: if `target_stake_scaling_factor = 10`, `rf = 0.004` and `max_oi = 120` then `target_stake = 4.8`.
 
 ### APIs
-* current (real-time) target stake to be available
+* target stake
+  * return current (real-time) target stake when market is in default trading mode.
+  * return theoretical (based on idicative uncrossing volume) target stake when market is in auction mode.
 
 ### Acceptance Criteria
 * examples showing a growing list (before we hit t-window)


### PR DESCRIPTION
Updated specs to reflect the facts that:
* when opening auction gets extended by liquidity auction the `auction extension trigger` should reflect that.
* we want market data API to return theoretical target stake during auction.

Also, updated market data API spec to reflect fields currently being returned.

Closes #569 