### PR TITLE
Use command line option to generate report file after upgrading godog to 0.11.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,9 +35,8 @@ pipeline {
             steps {
                 retry(3) {
                     dir('vega/integration') {
-                        sh 'godog -format=junit ../../specs-internal/qa-scenarios/ | grep -v "^202" | grep -v "^\\s*$" > qa-scenarios-report.xml'
+                        sh 'godog --format=junit:qa-scenarios-report.xml ../../specs-internal/qa-scenarios/'
                         junit skipPublishingChecks: true, testResults: 'qa-scenarios-report.xml'
-                        sh 'godog ../../specs-internal/qa-scenarios/'
                     }
                 }
             }


### PR DESCRIPTION
Part of #595 - godog got upgraded in vegaprotocol/vega#3799, which allow us to use the `--format=junit:qa-scenarios-report.xml` option that automatically saves JUnit report into a file directly.