### PR TITLE
Update milestone for Sweetwater++

### DIFF
--- a/non-protocol-specs/0003-limits-aka-training-wheels.md
+++ b/non-protocol-specs/0003-limits-aka-training-wheels.md
@@ -30,7 +30,7 @@ For Sweetwater, we only require the ability to:
 
 At genesis, Sweetwater will be started with only one asset: VEGA. As no new assets can be proposed (limit 2), only VEGA tokens can be deposited or withdrawn via the bridge. There will be no markets at genesis, and due to point 1 above, no markets can be created.
 
-### Oregon Tail
+### Sweetwater++
 
 We have identified three types of limit/control that will together achieve these aims:
 


### PR DESCRIPTION
Currently the work to limit deposits, withdrawals and a global stop is defined to be done in Oregon Trail. This has now ben scoped into Sweetwater++ therefore this PR updates the milestone to be Sweetwater++