### PR TITLE
Copy staking and delegation feature tests

### DIFF
--- a/qa-scenarios/0061-delegation-rewards-genesis.feature
+++ b/qa-scenarios/0061-delegation-rewards-genesis.feature
@@ -1,0 +1,663 @@
+Feature: Staking & Delegation - scenarios focusing on initial epoch
+
+  Background:
+    Given the following network parameters are set:
+      | name                                              |  value  |
+      | reward.asset                                      |  VEGA   |
+      | validators.epoch.length                           |  24h    |
+      | validators.delegation.minAmount                   |  10     |
+      | reward.staking.delegation.payoutDelay             |  0s     |
+      | reward.staking.delegation.delegatorShare          |  0.883  |
+      | reward.staking.delegation.minimumValidatorStake   |  100    |
+      | reward.staking.delegation.payoutFraction          |  0.5    |
+      | reward.staking.delegation.maxPayoutPerParticipant |  100000 |
+      | reward.staking.delegation.competitionLevel        |  1.1    |
+      | reward.staking.delegation.maxPayoutPerEpoch       |  50000  |
+  
+    And the average block duration is "1"
+    And time is updated to "2021-09-10T00:00:00Z"
+ 
+    And the validators:
+      | id     | staking account balance |
+      | node1  |         1000000         |
+      | node2  |         1000000         |
+      | node3  |         1000000         |
+      | node4  |         1000000         |
+      | node5  |         1000000         |
+      | node6  |         1000000         |
+      | node7  |         1000000         |
+      | node8  |         1000000         |
+      | node9  |         1000000         |
+      | node10 |         1000000         |
+      | node11 |         1000000         |
+      | node12 |         1000000         |
+      | node13 |         1000000         |
+
+  Scenario: No delegation in the first epoch
+
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+    
+    Then the network moves ahead "172804" blocks
+
+    And the parties receive the following reward for epoch 1:
+      | party  | asset | amount |
+      | node1  | VEGA  |     0  | 
+      | node2  | VEGA  |     0  | 
+      | node3  | VEGA  |     0  | 
+      | node4  | VEGA  |     0  | 
+      | node5  | VEGA  |     0  | 
+      | node6  | VEGA  |     0  | 
+      | node8  | VEGA  |     0  | 
+      | node10 | VEGA  |     0  | 
+      | node11 | VEGA  |     0  | 
+      | node12 | VEGA  |     0  | 
+      | node13 | VEGA  |     0  | 
+
+    Then the network moves ahead "86403" blocks
+
+    And the parties receive the following reward for epoch 2:
+      | party  | asset | amount |
+      | node1  | VEGA  |     0  | 
+      | node2  | VEGA  |     0  | 
+      | node3  | VEGA  |     0  | 
+      | node4  | VEGA  |     0  | 
+      | node5  | VEGA  |     0  | 
+      | node6  | VEGA  |     0  | 
+      | node8  | VEGA  |     0  | 
+      | node10 | VEGA  |     0  | 
+      | node11 | VEGA  |     0  | 
+      | node12 | VEGA  |     0  | 
+      | node13 | VEGA  |     0  | 
+
+    And the parties deposit on asset's general account the following amount:
+      | party  | asset  | amount |
+      | party1 | VEGA   | 111000 |
+
+    And the parties deposit on staking account the following amount:
+      | party  | asset  | amount |
+      | party1 | VEGA   | 111000 |  
+
+    #set up the self delegation of the validators (number of validators < min. validators parameter)
+    Then the parties submit the following delegations:
+      | party  | node id  | amount |
+      | node1  |  node1   |  11000 | 
+      | node2  |  node2   |  12000 | 
+      | node3  |  node3   |  13000 | 
+      | node4  |  node4   |     99 | 
+      | party1 |  node4   | 111000 | 
+
+    And the parties should have the following delegation balances for epoch 4:
+      | party  | node id  | amount |
+      | node1  |  node1   |  11000 | 
+      | node2  |  node2   |  12000 |       
+      | node3  |  node3   |  13000 |  
+      | node4  |  node4   |     99 |  
+      | party1 |  node4   | 111000 |  
+
+    Then the network moves ahead "172804" blocks
+
+    And the parties should have the following delegation balances for epoch 4:
+      | party  | node id  | amount |
+      | node1  |  node1   |  11000 | 
+      | node2  |  node2   |  12000 |       
+      | node3  |  node3   |  12446 |  
+      | node4  |  node4   |     99 |  
+      | party1 |  node4   |  12347 |  
+    
+    Then the validators should have the following val scores for epoch 4:
+      | node id | validator score  | normalised score |
+      |  node1  |      0.08462     |     0.25000      |    
+      |  node2  |      0.08462     |     0.25000      |
+      |  node3  |      0.08462     |     0.25000      | 
+      |  node4  |      0.08462     |     0.25000      | 
+      |  node5  |      0.00000     |     0.00000      | 
+      |  node6  |      0.00000     |     0.00000      | 
+      |  node7  |      0.00000     |     0.00000      | 
+      |  node8  |      0.00000     |     0.00000      | 
+      |  node9  |      0.00000     |     0.00000      | 
+      |  node10 |      0.00000     |     0.00000      | 
+      |  node11 |      0.00000     |     0.00000      | 
+      |  node12 |      0.00000     |     0.00000      | 
+      |  node13 |      0.00000     |     0.00000      |
+
+    And the parties receive the following reward for epoch 4:
+      | party  | asset | amount |
+      | party1 | VEGA  | 10949  | 
+      | node1  | VEGA  | 12500  | 
+      | node2  | VEGA  | 12500  | 
+      | node3  | VEGA  | 12500  | 
+      | node4  | VEGA  |     0  | 
+      | node5  | VEGA  |     0  | 
+      | node6  | VEGA  |     0  | 
+      | node8  | VEGA  |     0  | 
+      | node10 | VEGA  |     0  | 
+      | node11 | VEGA  |     0  | 
+      | node12 | VEGA  |     0  | 
+      | node13 | VEGA  |     0  | 
+
+  Scenario: Only a few validators self-delegate, no delegation
+
+    #set up the self delegation of the validators (number of validators = min. validators parameter)
+    Then the parties submit the following delegations:
+      | party  | node id  | amount |
+      | node1  |  node1   | 11000  | 
+      | node2  |  node2   | 12000  |       
+      | node3  |  node3   | 13000  | 
+      | node4  |  node4   | 14000  | 
+      | node5  |  node5   | 15000  | 
+
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+    
+    #complete the initial epoch for delegation to take effect
+    Then the network moves ahead "172804" blocks
+
+    Then the validators should have the following val scores for epoch 1:
+      | node id | validator score  | normalised score |
+      |  node1  |      0.08462     |     0.20000      |    
+      |  node2  |      0.08462     |     0.20000      |
+      |  node3  |      0.08462     |     0.20000      | 
+      |  node4  |      0.08462     |     0.20000      | 
+      |  node5  |      0.08462     |     0.20000      | 
+      |  node6  |      0.00000     |     0.00000      | 
+      |  node7  |      0.00000     |     0.00000      | 
+      |  node8  |      0.00000     |     0.00000      | 
+      |  node9  |      0.00000     |     0.00000      | 
+      |  node10 |      0.00000     |     0.00000      | 
+      |  node11 |      0.00000     |     0.00000      | 
+      |  node12 |      0.00000     |     0.00000      | 
+      |  node13 |      0.00000     |     0.00000      | 
+
+    And the parties receive the following reward for epoch 1:
+      | party  | asset | amount |
+      | node1  | VEGA  | 10000  | 
+      | node2  | VEGA  | 10000  | 
+      | node3  | VEGA  | 10000  | 
+      | node4  | VEGA  | 10000  | 
+      | node5  | VEGA  | 10000  | 
+      | node6  | VEGA  |     0  | 
+      | node8  | VEGA  |     0  | 
+      | node10 | VEGA  |     0  | 
+      | node11 | VEGA  |     0  | 
+      | node12 | VEGA  |     0  | 
+      | node13 | VEGA  |     0  | 
+
+  Scenario: Only a few validators self-delegate, small delegation to a single validator (with own stake). Some validators delegate over max delegatable amount.
+
+    And the parties deposit on asset's general account the following amount:
+      | party  | asset  | amount |
+      | party1 | VEGA   |     10 |
+      | party2 | VEGA   |     50 |
+      | party3 | VEGA   |    200 |
+
+    And the parties deposit on staking account the following amount:
+      | party  | asset  | amount |
+      | party1 | VEGA   |     10 |  
+      | party2 | VEGA   |     50 |  
+      | party3 | VEGA   |    200 |  
+
+    Then the parties submit the following delegations:
+      | party  | node id  |  amount |
+      | party1 |  node1   |      10 | 
+      | party2 |  node1   |      50 | 
+      | party3 |  node1   |     200 | 
+
+    #set up the self delegation of the validators (number of validators = min. validators parameter)
+    Then the parties submit the following delegations:
+      | party  | node id  | amount |
+      | node1  |  node1   |   100  | 
+      | node2  |  node2   |   200  |       
+      | node3  |  node3   |   300  | 
+      | node4  |  node4   |   400  | 
+      | node5  |  node5   |   500  | 
+
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+    
+    #complete the initial epoch for delegation to take effect
+    Then the network moves ahead "172804" blocks
+
+    And the parties should have the following delegation balances for epoch 1:
+      | party  | node id  |  amount |
+      | node1  |  node1   |     100 | 
+      | node2  |  node2   |     148 |       
+      | node3  |  node3   |     148 |  
+      | party1 |  node1   |      10 |  
+      | party2 |  node1   |      38 |  
+      | party3 |  node1   |       0 |  
+
+    Then the validators should have the following val scores for epoch 1:
+      | node id | validator score  | normalised score |
+      |  node1  |      0.08462     |     0.20000      |    
+      |  node2  |      0.08462     |     0.20000      |
+      |  node3  |      0.08462     |     0.20000      | 
+      |  node4  |      0.08462     |     0.20000      | 
+      |  node5  |      0.08462     |     0.20000      | 
+      |  node6  |      0.00000     |     0.00000      | 
+      |  node7  |      0.00000     |     0.00000      | 
+      |  node8  |      0.00000     |     0.00000      | 
+      |  node9  |      0.00000     |     0.00000      | 
+      |  node10 |      0.00000     |     0.00000      | 
+      |  node11 |      0.00000     |     0.00000      | 
+      |  node12 |      0.00000     |     0.00000      | 
+      |  node13 |      0.00000     |     0.00000      | 
+
+    And the parties receive the following reward for epoch 1:
+      | party  | asset | amount |
+      | party1 | VEGA  |   596  | 
+      | party2 | VEGA  |  2266  | 
+      | party3 | VEGA  |     0  | 
+      | node1  | VEGA  |  7136  | 
+      | node2  | VEGA  | 10000  | 
+      | node3  | VEGA  | 10000  |  
+      | node4  | VEGA  | 10000  | 
+      | node5  | VEGA  | 10000  | 
+      | node6  | VEGA  | 0      | 
+      | node7  | VEGA  | 0      | 
+      | node8  | VEGA  | 0      | 
+      | node10 | VEGA  | 0      | 
+      | node11 | VEGA  | 0      | 
+      | node12 | VEGA  | 0      | 
+      | node13 | VEGA  | 0      | 
+
+  Scenario: Only a few validators self-delegate, significant delegation to a three validators only (one w/o own stake)
+
+    And the parties deposit on asset's general account the following amount:
+      | party  | asset  | amount |
+      | party1 | VEGA   | 111000 |
+      | party2 | VEGA   | 222000 |
+      | party3 | VEGA   | 333000 |
+      | party4 | VEGA   | 444000 |
+      | party5 | VEGA   | 555000 |
+  
+    And the parties deposit on staking account the following amount:
+      | party  | asset  | amount |
+      | party1 | VEGA   | 111000 |  
+      | party2 | VEGA   | 222000 |  
+      | party3 | VEGA   | 333000 |  
+      | party4 | VEGA   | 444000 |  
+      | party5 | VEGA   | 555000 |  
+  
+    Then the parties submit the following delegations:
+      | party  | node id  | amount |
+      | node1  |  node1   | 11000  | 
+      | node2  |  node2   | 12000  |       
+      | node3  |  node3   | 13000  | 
+      | node4  |  node4   | 14000  | 
+      | node5  |  node5   | 15000  | 
+      | node6  |  node6   | 16000  | 
+  
+    Then the parties submit the following delegations:
+      | party  | node id  | amount  |
+      | party1 |  node1   |  111000 | 
+      | party2 |  node2   |  111000 | 
+      | party2 |  node7   |  111000 | 
+      | party3 |  node1   |  111000 | 
+      | party3 |  node2   |  111000 | 
+      | party3 |  node7   |  111000 | 
+      | party4 |  node1   |  222000 | 
+      | party4 |  node7   |  222000 | 
+      | party5 |  node2   |  555000 | 
+  
+    #set up the self delegation of the validators (number of validators > min. validators parameter)
+    And the parties should have the following delegation balances for epoch 1:
+      | party  | node id  | amount  |
+      | node1  |  node1   |   11000 | 
+      | node2  |  node2   |   12000 |       
+      | node3  |  node3   |   13000 |  
+      | node4  |  node4   |   14000 |  
+      | node5  |  node5   |   15000 |  
+      | node6  |  node6   |   16000 |  
+      | node7  |  node7   |       0 |  
+      | party1 |  node1   |  111000 | 
+      | party2 |  node2   |  111000 | 
+      | party2 |  node7   |  111000 | 
+      | party3 |  node1   |  111000 | 
+      | party3 |  node2   |  111000 | 
+      | party3 |  node7   |  111000 | 
+      | party4 |  node1   |  222000 | 
+      | party4 |  node7   |  222000 | 
+      | party5 |  node2   |  555000 | 
+  
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+    
+    #complete the initial epoch for delegation to take effect
+    Then the network moves ahead "172804" blocks
+  
+    And the parties should have the following delegation balances for epoch 1:
+      | party  | node id  |  amount |
+      | node1  |  node1   |   11000 | 
+      | node2  |  node2   |   12000 |       
+      | node3  |  node3   |   13000 |  
+      | node4  |  node4   |   14000 |  
+      | node5  |  node5   |   15000 |  
+      | node6  |  node6   |   16000 |  
+      | node7  |  node7   |       0 |  
+      | party1 |  node1   |  111000 | 
+      | party2 |  node2   |  111000 | 
+      | party2 |  node7   |  111000 | 
+      | party3 |  node1   |   25738 | 
+      | party3 |  node2   |   24738 | 
+      | party3 |  node7   |   36738 | 
+      | party4 |  node1   |       0 | 
+      | party4 |  node7   |       0 | 
+      | party5 |  node2   |       0 | 
+  
+    Then the validators should have the following val scores for epoch 1:
+      | node id | validator score  | normalised score |
+      |  node1  |      0.08462     |     0.22896      |    
+      |  node2  |      0.08462     |     0.22896      |
+      |  node3  |      0.02594     |     0.07018      | 
+      |  node4  |      0.02793     |     0.07558      | 
+      |  node5  |      0.02993     |     0.08098      | 
+      |  node6  |      0.03192     |     0.08638      | 
+      |  node7  |      0.08462     |     0.22896      | 
+      |  node8  |      0.00000     |     0.00000      | 
+      |  node9  |      0.00000     |     0.00000      | 
+      |  node10 |      0.00000     |     0.00000      | 
+      |  node11 |      0.00000     |     0.00000      | 
+      |  node12 |      0.00000     |     0.00000      | 
+      |  node13 |      0.00000     |     0.00000      | 
+  
+    And the parties receive the following reward for epoch 1:
+      | party  | asset | amount |
+      | party1 | VEGA  | 7594   | 
+      | party2 | VEGA  | 15188  | 
+      | party3 | VEGA  | 5965   | 
+      | node1  | VEGA  | 2092   | 
+      | node2  | VEGA  | 2160   | 
+      | node3  | VEGA  | 3509   |  
+      | node4  | VEGA  | 3779   | 
+      | node5  | VEGA  | 4048   | 
+      | node6  | VEGA  | 4318   | 
+      | node7  | VEGA  | 0      | 
+      | node8  | VEGA  | 0      | 
+      | node10 | VEGA  | 0      | 
+      | node11 | VEGA  | 0      | 
+      | node12 | VEGA  | 0      | 
+      | node13 | VEGA  | 0      | 
+
+Scenario: Validator owns more tokens than the minimumValidatorStake, but most of them are delegated to a different validator, then withdraws so that he owns less than minimumValidatorStake
+
+  And the parties deposit on asset's general account the following amount:
+    | party  | asset  | amount |
+    | party1 | VEGA   | 111000 |
+    | party2 | VEGA   | 222000 |
+
+  And the parties deposit on staking account the following amount:
+    | party  | asset  | amount |
+    | party1 | VEGA   | 111000 |  
+    | party2 | VEGA   | 222000 |   
+
+  Then the parties submit the following delegations:
+    | party  | node id  | amount |
+    | node1  |  node1   |  11000 | 
+    | node2  |  node2   |     20 |       
+    | node3  |  node3   |     30 | 
+    | node4  |  node4   |  14000 | 
+    | node5  |  node5   |  15000 | 
+    | node6  |  node6   |  16000 | 
+    | node8  |  node8   |    110 |       
+    | node2  |  node7   |    180 |       
+    | node3  |  node7   |   3000 | 
+
+  Then the parties submit the following delegations:
+    | party  | node id  | amount  |
+    | party1 |  node1   |  111000 | 
+    | party2 |  node2   |  222000 | 
+
+  #set up the self delegation of the validators (number of validators > min. validators parameter)
+  And the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | node1  |  node1   |  11000 | 
+    | node2  |  node2   |     20 |       
+    | node3  |  node3   |     30 | 
+    | node4  |  node4   |  14000 | 
+    | node5  |  node5   |  15000 | 
+    | node6  |  node6   |  16000 | 
+    | node8  |  node8   |    110 |  
+    | node2  |  node7   |    180 |       
+    | node3  |  node7   |   3000 | 
+    | party1 |  node1   | 111000 | 
+    | party2 |  node2   | 222000 | 
+
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+    
+    #complete the initial epoch for delegation to take effect
+    Then the network moves ahead "172804" blocks
+
+    And the parties should have the following delegation balances for epoch 1:
+      | party  | node id  | amount |
+      | node1  |  node1   |  11000 | 
+      | node2  |  node2   |     20 |       
+      | node3  |  node3   |     30 | 
+      | node4  |  node4   |  14000 | 
+      | node5  |  node5   |  15000 | 
+      | node6  |  node6   |  16000 | 
+      | node8  |  node8   |    110 |       
+      | node2  |  node7   |    180 |       
+      | node3  |  node7   |   3000 | 
+      | party1 |  node1   |  22197 | 
+      | party2 |  node2   |  33177 | 
+
+    Then the validators should have the following val scores for epoch 1:
+      | node id | validator score  | normalised score |
+      |  node1  |      0.08462     |     0.18719      |    
+      |  node2  |      0.08462     |     0.18719      |
+      |  node3  |      0.00026     |     0.00058      | 
+      |  node4  |      0.08462     |     0.18719      | 
+      |  node5  |      0.08462     |     0.18719      | 
+      |  node6  |      0.08462     |     0.18719      | 
+      |  node7  |      0.02772     |     0.06133      | 
+      |  node8  |      0.00096     |     0.00212      | 
+      |  node9  |      0.00000     |     0.00000      | 
+      |  node10 |      0.00000     |     0.00000      | 
+      |  node11 |      0.00000     |     0.00000      | 
+      |  node12 |      0.00000     |     0.00000      | 
+      |  node13 |      0.00000     |     0.00000      | 
+
+    And the parties receive the following reward for epoch 1:
+      | party  | asset | amount |
+      | party1 | VEGA  | 5526   | 
+      | party2 | VEGA  | 8259   | 
+      | node1  | VEGA  | 3833   | 
+      | node2  | VEGA  | 153    | 
+      | node3  | VEGA  | 2553   |  
+      | node4  | VEGA  | 9359   | 
+      | node5  | VEGA  | 9359   | 
+      | node6  | VEGA  | 9359   | 
+      | node7  | VEGA  | 0      | 
+      | node8  | VEGA  | 106    | 
+      | node10 | VEGA  | 0      | 
+      | node11 | VEGA  | 0      | 
+      | node12 | VEGA  | 0      | 
+      | node13 | VEGA  | 0      | 
+
+   # Leave 20 in the account
+   Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | node2  | VEGA   | 999980 | 
+
+  And the parties submit the following undelegations:
+    | party | node id | amount | when |
+    | node3 |  node7  |   2900 | now  |
+    | node8 |  node8  |     60 | now  |
+
+  Then the network moves ahead "1" blocks
+
+  # Delegation changes due to undelegation are immediate, need to complete the epoch for withdrawal to get registered
+  And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | node1  |  node1   |  11000 | 
+    | node2  |  node2   |     20 |       
+    | node3  |  node3   |     30 | 
+    | node4  |  node4   |  14000 | 
+    | node5  |  node5   |  15000 | 
+    | node6  |  node6   |  16000 | 
+    | node8  |  node8   |     50 |       
+    | node2  |  node7   |    180 |       
+    | node3  |  node7   |    100 | 
+    | party1 |  node1   |  22197 | 
+    | party2 |  node2   |  33177 | 
+
+  Then the network moves ahead "86401" blocks
+
+  And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | node1  |  node1   |  11000 | 
+    | node2  |  node2   |      2 |       
+    | node3  |  node3   |     30 | 
+    | node4  |  node4   |  14000 | 
+    | node5  |  node5   |  15000 | 
+    | node6  |  node6   |  16000 | 
+    | node8  |  node8   |     50 |       
+    | node2  |  node7   |     18 |       
+    | node3  |  node7   |    100 | 
+    | party1 |  node1   |  22197 | 
+    | party2 |  node2   |  33177 | 
+
+Scenario: In presence of max delegation cap self-delegation gets priorities even if submitted later
+
+  Given the parties deposit on asset's general account the following amount:
+    | party  | asset  | amount |
+    | party1 | VEGA   | 111000 |
+    | party2 | VEGA   | 222000 |
+
+  And the parties deposit on staking account the following amount:
+    | party  | asset  | amount |
+    | party1 | VEGA   | 111000 |  
+    | party2 | VEGA   | 222000 |   
+
+  Then the parties submit the following delegations:
+    | party  | node id  | amount  |
+    | party1 |  node1   |  111000 | 
+    | party2 |  node2   |  222000 | 
+
+  Then the network moves ahead "1" blocks
+
+  Then the parties submit the following delegations:
+    | party  | node id  | amount |
+    | node1  |  node1   | 100000 | 
+    | node2  |  node2   |  12000 |       
+    | node3  |  node3   |  13000 | 
+    | node4  |  node4   |  14000 | 
+    | node5  |  node5   |  15000 | 
+    | node6  |  node6   |  16000 | 
+
+  Then the network moves ahead "1" blocks
+
+  And the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | node1  |  node1   | 100000 | 
+    | node2  |  node2   |  12000 |       
+    | node3  |  node3   |  13000 | 
+    | node4  |  node4   |  14000 | 
+    | node5  |  node5   |  15000 | 
+    | node6  |  node6   |  16000 | 
+    | party1 |  node1   | 111000 | 
+    | party2 |  node2   | 222000 | 
+
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+    
+    #complete the initial epoch for delegation to take effect
+    Then the network moves ahead "172802" blocks
+
+    And the parties should have the following delegation balances for epoch 1:
+      | party  | node id  | amount |
+      | node1  |  node1   |  42561 | 
+      | node2  |  node2   |  12000 |       
+      | node3  |  node3   |  13000 | 
+      | node4  |  node4   |  14000 | 
+      | node5  |  node5   |  15000 | 
+      | node6  |  node6   |  16000 | 
+      | party1 |  node1   |      0 | 
+      | party2 |  node2   |  30561 | 
+
+    Then the validators should have the following val scores for epoch 1:
+      | node id | validator score  | normalised score |
+      |  node1  |      0.08462     |     0.16667      |    
+      |  node2  |      0.08462     |     0.16667      |
+      |  node3  |      0.08462     |     0.16667      | 
+      |  node4  |      0.08462     |     0.16667      | 
+      |  node5  |      0.08462     |     0.16667      | 
+      |  node6  |      0.08462     |     0.16667      | 
+      |  node7  |      0.00000     |     0.00000      | 
+      |  node8  |      0.00000     |     0.00000      | 
+      |  node9  |      0.00000     |     0.00000      | 
+      |  node10 |      0.00000     |     0.00000      | 
+      |  node11 |      0.00000     |     0.00000      | 
+      |  node12 |      0.00000     |     0.00000      | 
+      |  node13 |      0.00000     |     0.00000      | 
+
+    And the parties receive the following reward for epoch 1:
+      | party  | asset | amount |
+      | party1 | VEGA  | 0      | 
+      | party2 | VEGA  | 5283   | 
+      | node1  | VEGA  | 8333   | 
+      | node2  | VEGA  | 3049   | 
+      | node3  | VEGA  | 8333   |  
+      | node4  | VEGA  | 8333   | 
+      | node5  | VEGA  | 8333   | 
+      | node6  | VEGA  | 8333   | 
+      | node7  | VEGA  | 0      | 
+      | node8  | VEGA  | 0      | 
+      | node10 | VEGA  | 0      | 
+      | node11 | VEGA  | 0      | 
+      | node12 | VEGA  | 0      | 
+      | node13 | VEGA  | 0      | 
+
+Scenario: Validator subset can self-delegate as to push themselves below min validator stake due to max delegatable amount cap
+
+  Then the parties submit the following delegations:
+    | party  | node id  | amount |
+    | node1  |  node1   |    100 | 
+    | node2  |  node2   |    200 |       
+    | node3  |  node3   |    300 | 
+
+  Then the network moves ahead "1" blocks
+
+  And the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | node1  |  node1   |    100 | 
+    | node2  |  node2   |    200 |       
+    | node3  |  node3   |    300 | 
+    | node4  |  node4   |      0 | 
+
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+    
+    #complete the initial epoch for delegation to take effect
+    Then the network moves ahead "172802" blocks
+
+    And the parties should have the following delegation balances for epoch 1:
+      | party  | node id  | amount |
+      | node1  |  node1   |     50 | 
+      | node2  |  node2   |     50 |       
+      | node3  |  node3   |     50 | 
+      | node4  |  node4   |     0  | 
+
+    And the parties receive the following reward for epoch 1:
+      | party  | asset | amount |
+      | node1  | VEGA  | 0      | 
+      | node2  | VEGA  | 0      | 
+      | node3  | VEGA  | 0      |  
+      | node4  | VEGA  | 0      | 
+      | node5  | VEGA  | 0      | 
+      | node6  | VEGA  | 0      | 
+      | node7  | VEGA  | 0      | 
+      | node8  | VEGA  | 0      | 
+      | node10 | VEGA  | 0      | 
+      | node11 | VEGA  | 0      | 
+      | node12 | VEGA  | 0      | 
+      | node13 | VEGA  | 0      | 

--- a/qa-scenarios/0061-delegation-rewards.feature
+++ b/qa-scenarios/0061-delegation-rewards.feature
@@ -1,0 +1,836 @@
+Feature: Staking & Delegation 
+
+  Background:
+    Given the following network parameters are set:
+      | name                                              |  value                   |
+      | reward.asset                                      |  VEGA                    |
+      | validators.epoch.length                           |  10s                     |
+      | validators.delegation.minAmount                   |  10                      |
+      | reward.staking.delegation.payoutDelay             |  0s                      |
+      | reward.staking.delegation.delegatorShare          |  0.883                   |
+      | reward.staking.delegation.minimumValidatorStake   |  100                     |
+      | reward.staking.delegation.payoutFraction          |  0.5                     |
+      | reward.staking.delegation.maxPayoutPerParticipant | 100000                   |
+      | reward.staking.delegation.competitionLevel        |  1.1                     |
+      | reward.staking.delegation.maxPayoutPerEpoch       |  50000                   |
+
+
+    Given time is updated to "2021-08-26T00:00:00Z"
+    Given the average block duration is "2"
+
+    And the validators:
+      | id     | staking account balance |
+      | node1  |         1000000         |
+      | node2  |         1000000         |
+      | node3  |         1000000         |
+      | node4  |         1000000         |
+      | node5  |         1000000         |
+      | node6  |         1000000         |
+      | node7  |         1000000         |
+      | node8  |         1000000         |
+      | node9  |         1000000         |
+      | node10 |         1000000         |
+      | node11 |         1000000         |
+      | node12 |         1000000         |
+      | node13 |         1000000         |
+
+    #set up the self delegation of the validators
+    Then the parties submit the following delegations:
+      | party  | node id  | amount |
+      | node1  |  node1   | 10000  | 
+      | node2  |  node2   | 10000  |       
+      | node3  |  node3   | 10000  | 
+      | node4  |  node4   | 10000  | 
+      | node5  |  node5   | 10000  | 
+      | node6  |  node6   | 10000  | 
+      | node7  |  node7   | 10000  | 
+      | node8  |  node8   | 10000  | 
+      | node9  |  node9   | 10000  | 
+      | node10 |  node10  | 10000  | 
+      | node11 |  node11  | 10000  | 
+      | node12 |  node12  | 10000  | 
+      | node13 |  node13  | 10000  | 
+
+    And the parties deposit on staking account the following amount:
+      | party  | asset  | amount |
+      | party1 | VEGA   | 10000  |  
+
+    Then the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  100   | 
+    | party1 |  node2   |  200   |       
+    | party1 |  node3   |  300   |     
+
+    #complete the first epoch for the self delegation to take effect
+    Then the network moves ahead "7" blocks
+
+   Scenario: Parties get rewarded for a full epoch of having delegated stake
+    Desciption: Parties have had their tokens delegated to nodes for a full epoch and get rewarded for the full epoch. 
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+
+    #advance to the end of the epoch / start next epoch
+    Then the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 1:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      | 
+
+  Scenario: No funds in reward account however validator scores get published
+    Desciption: Parties have had their tokens delegated to nodes for a full epoch but the reward account balance is 0
+
+    #advance to the end of the epoch / start next epoch
+    When the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 1:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      | 
+
+  Scenario: Parties get rewarded for a full epoch of having delegated stake - the reward amount is capped 
+    Desciption: Parties have had their tokens delegated to nodes for a full epoch and get rewarded for the full epoch. 
+    
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 120000 |   
+
+    #the available amount for the epoch is 60k but it is capped to 50 by the max.  
+
+    #advance to the end of the epoch
+    Then the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 1:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      | 
+
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party2 
+    #node3 has 10k self delegation + 300 from party3 
+    #all other nodes have 10k self delegation 
+    #party1 gets 0.07734 * 50000 * 0.883 * 100/10100 + 0.07810 * 50000 * 0.883 * 200/10200 + 0.07887 * 50000 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 50000
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 50000
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 50000
+    #node4 - node13 gets: 0.07657 * 50000
+    And the parties receive the following reward for epoch 1:
+    | party  | asset | amount |
+    | party1 | VEGA  |  201   | 
+    | node1  | VEGA  |  3832  | 
+    | node2  | VEGA  |  3837  | 
+    | node3  | VEGA  |  3841  | 
+    | node4  | VEGA  |  3828  | 
+    | node5  | VEGA  |  3828  | 
+    | node6  | VEGA  |  3828  | 
+    | node8  | VEGA  |  3828  | 
+    | node10 | VEGA  |  3828  | 
+    | node11 | VEGA  |  3828  | 
+    | node12 | VEGA  |  3828  | 
+    | node13 | VEGA  |  3828  | 
+
+  Scenario: Parties request to undelegate at the end of the epoch. They get fully rewarded for the current epoch and not get rewarded in the following epoch for the undelegated stake
+    Desciption: Parties have had their tokens delegated to nodes for a full epoch and get rewarded for the full epoch. During the epoch however they request to undelegate at the end of the epoch part of their stake. On the following epoch they are not rewarded for the undelegated stake. 
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount | when         |
+    | party1 |  node2   |  150   | end of epoch |      
+    | party1 |  node3   |  300   | end of epoch |
+
+
+    #advance to the end of the epoch
+    When the network moves ahead "7" blocks
+
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party2 
+    #node3 has 10k self delegation + 300 from party3 
+    #all other nodes have 10k self delegation 
+    #party1 gets 0.07734 * 50000 * 0.883 * 100/10100 + 0.07810 * 50000 * 0.883 * 200/10200 + 0.07887 * 50000 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 50000
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 50000
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 50000
+    #node4 - node13 gets: 0.07657 * 50000
+    And the parties receive the following reward for epoch 1:
+    | party  | asset | amount |
+    | party1 | VEGA  |  201   | 
+    | node1  | VEGA  |  3832  | 
+    | node2  | VEGA  |  3837  | 
+    | node3  | VEGA  |  3841  | 
+    | node4  | VEGA  |  3828  | 
+    | node5  | VEGA  |  3828  | 
+    | node6  | VEGA  |  3828  | 
+    | node7  | VEGA  |  3828  | 
+    | node8  | VEGA  |  3828  | 
+    | node9  | VEGA  |  3828  | 
+    | node10 | VEGA  |  3828  | 
+    | node11 | VEGA  |  3828  | 
+    | node12 | VEGA  |  3828  | 
+    | node13 | VEGA  |  3828  | 
+
+    #advance to the beginning and end of the following epoch 
+    When the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 2:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07760     |     0.07760      |    
+    |  node2  |      0.07722     |     0.07722      |
+    |  node3  |      0.07683     |     0.07683      | 
+
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 50 from party2 
+    #all other nodes have 10k self delegation 
+    #party1 gets 0.0776 * 25004 * 0.883 * 100/10100 + 0.07722 * 25004 * 0.883 * 50/10050
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.0776 * 25004
+    #node2 gets: (1 - 0.883 * 50/10050) * 0.07722 * 25004
+    #node4 - node13 gets: 0.07683 * 25004
+    And the parties receive the following reward for epoch 2:
+    | party  | asset | amount |
+    | party1 | VEGA  |  24    | 
+    | node1  | VEGA  |  1923  | 
+    | node2  | VEGA  |  1922  | 
+    | node3  | VEGA  |  1921  | 
+    | node4  | VEGA  |  1921  | 
+    | node5  | VEGA  |  1921  | 
+    | node6  | VEGA  |  1921  | 
+    | node7  | VEGA  |  1921  | 
+    | node8  | VEGA  |  1921  | 
+    | node9  | VEGA  |  1921  | 
+    | node10 | VEGA  |  1921  | 
+    | node11 | VEGA  |  1921  | 
+    | node12 | VEGA  |  1921  | 
+    | node13 | VEGA  |  1921  | 
+
+  Scenario: Parties request to undelegate now during the epoch. They only get rewarded for the current epoch for the fraction that remained for the whole duration 
+    Desciption: Parties have had their tokens delegated to nodes for a full epoch and get rewarded for the full epoch. During the epoch however they request to undelegate at the end of the epoch part of their stake. On the following epoch they are not rewarded for the undelegated stake. 
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+      
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount | when |
+    | party1 |  node2   |  150   | now  |      
+    | party1 |  node3   |  300   | now  |
+
+    #advance to the end of the epoch
+    When the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 1:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07760     |     0.07760      |    
+    |  node2  |      0.07722     |     0.07722      |
+    |  node3  |      0.07683     |     0.07683      | 
+
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 50 from party2 
+    #all other nodes have 10k self delegation 
+
+    #party1 gets 0.07760 * 50000 * 0.883 * 100/10100 + 0.07722 * 50000 * 0.883 * 50/10050 
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07760 * 50000
+    #node2 gets: (1 - 0.883 * 50/10050) * 0.07722 * 50000
+    #node3 - node13 gets: 0.07683 * 50000
+    And the parties receive the following reward for epoch 1:
+    | party  | asset | amount |
+    | party1 | VEGA  |  49    | 
+    | node1  | VEGA  |  3846  | 
+    | node2  | VEGA  |  3843  | 
+    | node3  | VEGA  |  3841  | 
+    | node4  | VEGA  |  3841  | 
+    | node5  | VEGA  |  3841  | 
+    | node6  | VEGA  |  3841  | 
+    | node7  | VEGA  |  3841  | 
+    | node8  | VEGA  |  3841  | 
+    | node9  | VEGA  |  3841  | 
+    | node10 | VEGA  |  3841  | 
+    | node11 | VEGA  |  3841  | 
+    | node12 | VEGA  |  3841  | 
+    | node13 | VEGA  |  3841  | 
+
+  Scenario: Parties withdraw from their staking account during an epoch once having active delegations - they should not get rewarded for those uncovered delegations 
+    Desciption: Parties have active delegations on epoch 1 and withdraw stake from the staking account. They should only get rewarded for any delegation that still has cover 
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+      
+    #party1 has a balance of 10k tokens in their staking account and an active delegation in this epoch of 600. By withdrawing 9850, 450 of their delegation needs to be revoked and they should only get rewarded for the 150 tokens
+    #NB: the undelegation is done proportionally to the stake they have in each node, so for example party1 has 100, 200, 300 in nodes 1-3 respectively so 
+    #after undelegation they will have 25, 50, 75 in nodes 1-3 respectively
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9850  |
+
+    #advance to the end of the epoch
+    When the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 1:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07703     |     0.07703      |    
+    |  node2  |      0.07722     |     0.07722      |
+    |  node3  |      0.07741     |     0.07741      | 
+    |  node4  |      0.07683     |     0.07683      | 
+
+    #node1 has 10k self delegation + 25 from party1
+    #node2 has 10k self delegation + 50 from party1
+    #node3 has 10k self delegation + 75 from party1
+    #all other nodes have 10k self delegation 
+
+    #party1 gets 0.07703 * 50000 * 0.883 * 25/10025 + 0.07722 * 50000 * 0.883 * 50/10050 + 0.07741 * 50000 * 0.883 * 75/10075
+    #node1 gets: (1 - 0.883 * 25/10025) * 0.07703 * 50000
+    #node2 gets: (1 - 0.883 * 50/10050) * 0.07722 * 50000
+    #node3 gets: (1 - 0.883 * 75/10075) * 0.07741 * 50000
+    #node4 - node13 get: 0.07683 * 50000
+
+    And the parties receive the following reward for epoch 1:
+    | party  | asset | amount |
+    | party1 | VEGA  |  49    | 
+    | node1  | VEGA  |  3842  | 
+    | node2  | VEGA  |  3843  | 
+    | node3  | VEGA  |  3845  | 
+    | node4  | VEGA  |  3841  | 
+    | node5  | VEGA  |  3841  | 
+    | node6  | VEGA  |  3841  | 
+    | node7  | VEGA  |  3841  | 
+    | node8  | VEGA  |  3841  | 
+    | node9  | VEGA  |  3841  | 
+    | node10 | VEGA  |  3841  | 
+    | node11 | VEGA  |  3841  | 
+    | node12 | VEGA  |  3841  | 
+    | node13 | VEGA  |  3841  | 
+
+    Then "party1" should have general account balance of "49" for asset "VEGA"
+    Then "node1" should have general account balance of "3842" for asset "VEGA"
+  
+  Scenario: Party has delegation unfunded for majority of the epoch (except for begining and end) - should get no rewards.
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+      
+    Given the parties withdraw from staking account the following amount:  
+      | party  | asset | amount |
+      | party1 | VEGA  |  9999  |
+
+    When the network moves ahead "6" blocks
+    
+    And the parties deposit on staking account the following amount:
+      | party  | asset | amount |
+      | party1 | VEGA  | 9999   |  
+
+    #advance to the end of the epoch
+    When the network moves ahead "1" blocks
+
+    And the parties receive the following reward for epoch 1:
+      | party  | asset | amount |
+      | party1 | VEGA  |  0     | 
+
+   Scenario: A party changes delegation from one validator to another in the same epoch
+   Description: A party can change delegation from one validator to another      
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+
+    When the network moves ahead "7" blocks
+
+    #now request to undelegate from node2 and node3 
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |      when     |
+    | party1 |  node2   |  180   |  end of epoch |     
+    | party1 |  node3   |  300   |  end of epoch | 
+    Then the parties submit the following delegations:
+    | party  | node id  | amount | 
+    | party1 |  node1   |  180   | 
+    | party1 |  node1   |  190   |  
+
+    #advance to the end of the epoch for the delegation to become effective
+    Then the network moves ahead "7" blocks    
+
+     #verify validator score 
+    Then the validators should have the following val scores for epoch 2:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      |
+
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party1
+    #node3 has 10k self delegation + 300 from party1
+    #all other nodes have 10k self delegation
+    #party1 gets 0.07734  * 25004 * 0.883 * 100/10100 + 0.07810 * 25004 * 0.883 * 200/10200 + 0.07887 * 25004 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 25004
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 25004
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 25004
+    #node4 - node13 gets: 0.07657 * 25004
+
+    And the parties receive the following reward for epoch 2:
+    | party  | asset | amount |
+    | party1 | VEGA  |  99    | 
+    | node1  | VEGA  |  1916  | 
+    | node2  | VEGA  |  1919  | 
+    | node3  | VEGA  |  1921  | 
+    | node4  | VEGA  |  1914  | 
+    | node5  | VEGA  |  1914  | 
+    | node6  | VEGA  |  1914  | 
+    | node7  | VEGA  |  1914  | 
+    | node8  | VEGA  |  1914  | 
+    | node9  | VEGA  |  1914  | 
+    | node10 | VEGA  |  1914  | 
+    | node11 | VEGA  |  1914  | 
+    | node12 | VEGA  |  1914  | 
+    | node13 | VEGA  |  1914  | 
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   | 470    | 
+    | party1 |  node2   | 20     |       
+    | party1 |  node3   |  0     | 
+
+     #advance to the beginning and end of the following epoch 
+    Then the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 3:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.08024     |     0.08024      |    
+    |  node2  |      0.07679     |     0.07679      |
+    |  node3  |      0.07663     |     0.07663      | 
+
+    #node1 has 10k self delegation + 470 from party1
+    #node2 has 10k self delegation + 20 from party1
+    #node3 has 10k self delegation + 0 from party1
+    #all other nodes have 10k self delegation
+    #party1 gets 0.08024 * 12506 * 0.883 * 470/10470 + 0.07679 * 12506 * 0.883 * 20/10020
+    #node1 gets: (1 - 0.883 * 470/10470)  * 0.08024 * 12506
+    #node2 gets: (1 - 0.883 * 20/10020) * 0.07679 * 12506
+    #node3 gets: (1 - 0.883 * 0/1000) * 0.07663 * 12506
+    #node4 - node13 gets: 0.07663 * 12506
+
+    And the parties receive the following reward for epoch 3:
+    | party  | asset | amount |
+    | party1 | VEGA  |  40    | 
+    | node1  | VEGA  |  963   | 
+    | node2  | VEGA  |  958   | 
+    | node3  | VEGA  |  958   | 
+    | node4  | VEGA  |  958   | 
+    | node5  | VEGA  |  958   | 
+    | node6  | VEGA  |  958   | 
+    | node7  | VEGA  |  958   | 
+    | node8  | VEGA  |  958   | 
+    | node9  | VEGA  |  958   | 
+    | node10 | VEGA  |  958   | 
+    | node11 | VEGA  |  958   | 
+    | node12 | VEGA  |  958   | 
+    | node13 | VEGA  |  958   | 
+  
+  Scenario: A party can request delegate and undelegate from the same node at the same epoch such that the request can balance each other without affecting the actual delegate balance
+    Description: party requests to delegate to node1 at the end of the epoch and regrets it and undelegate the whole amount to delegate it to another node
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |    when      |
+    | party1 |  node1   |  100   | end of epoch |
+    And the parties submit the following delegations:
+    | party  | node id  |  amount | 
+    | party1 |  node4   |   100   | 
+    #advance to the end of the epoch
+    Then the network moves ahead "7" blocks
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party1 
+    #node3 has 10k self delegation + 300 from party1 
+    #all other nodes have 10k self delegation 
+    #party1 gets 0.07734 * 50000 * 0.883 * 100/10100 + 0.07810 * 50000 * 0.883 * 200/10200 + 0.07887 * 50000 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 50000
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 50000
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 50000
+    #node4 - node13 gets: 0.07657 * 50000
+    And the parties receive the following reward for epoch 1:
+    | party  | asset | amount |
+    | party1 | VEGA  |  201   | 
+    | node1  | VEGA  |  3832  | 
+    | node2  | VEGA  |  3837  | 
+    | node3  | VEGA  |  3841  | 
+    | node4  | VEGA  |  3828  | 
+    | node5  | VEGA  |  3828  | 
+    | node6  | VEGA  |  3828  | 
+    | node7  | VEGA  |  3828  | 
+    | node8  | VEGA  |  3828  | 
+    | node9  | VEGA  |  3828  | 
+    | node10 | VEGA  |  3828  | 
+    | node11 | VEGA  |  3828  | 
+    | node12 | VEGA  |  3828  | 
+    | node13 | VEGA  |  3828  | 
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 0      | 
+    | party1 |  node4   | 100    | 
+    #advance to the beginning and end of the following epoch 
+    Then the network moves ahead "7" blocks
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 2:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07657     |     0.07657      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07734     |     0.07734      | 
+    |  node5  |      0.07657     |     0.07657      | 
+    #node1 has 10k self delegation
+    #node2 has 10k self delegation + 200 from party1
+    #node3 has 10k self delegation + 300 from party1 
+    #node4 has 10k self delegation + 100 from party1 
+    #all other nodes have 10k self delegation
+    #party1 gets 0.07657  * 25004 * 0.883 * 0/10100 + 0.07810 * 25004 * 0.883 * 200/10200 + 0.07887 * 25004 * 0.883 * 300/10300 + 0.07734 * 25004 * 0.883 * 100/10100
+    #node1 gets: (1 - 0.883 * 0/10100) * 0.07657 * 25004
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 25004
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 25004
+    #node4 gets: (1 - 0.883 * 100/10100) * 0.07734 * 25004
+    #node5 - node13 gets: 0.07657 * 25004
+    And the parties receive the following reward for epoch 2:
+    | party  | asset | amount |
+    | party1 | VEGA  |  99    | 
+    | node1  | VEGA  |  1914  | 
+    | node2  | VEGA  |  1919  | 
+    | node3  | VEGA  |  1921  | 
+    | node4  | VEGA  |  1916  | 
+    | node5  | VEGA  |  1914  | 
+    | node6  | VEGA  |  1914  | 
+    | node7  | VEGA  |  1914  | 
+    | node8  | VEGA  |  1914  | 
+    | node9  | VEGA  |  1914  | 
+    | node10 | VEGA  |  1914  | 
+    | node11 | VEGA  |  1914  | 
+    | node12 | VEGA  |  1914  | 
+    | node13 | VEGA  |  1914  | 
+  
+  Scenario: A party has active delegations and submits an undelegate request followed by a delegation request that covers only part of the undelegation such that the undelegation still takes place
+    Description: A party delegated tokens to node1 at previous epoch such that the delegations is now active and is requesting to undelegate some of the tokens at the end of the current epoch. Then regret some of it and submit a delegation request that undoes some of the undelegation but still some of it remains.
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+      
+    #advance to the end of the epoch
+    Then the network moves ahead "7" blocks
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |    when      |
+    | party1 |  node1   |  100   | end of epoch |
+    And the parties submit the following delegations:
+    | party  | node id  |  amount | 
+    | party1 |  node1   |    50   |
+    When the network moves ahead "7" blocks
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 2:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      |
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party1
+    #node3 has 10k self delegation + 300 from party1
+    #all other nodes have 10k self delegation
+    #party1 gets 0.07734  * 25004 * 0.883 * 100/10100 + 0.07810 * 25004 * 0.883 * 200/10200 + 0.07887 * 25004 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 25004
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 25004
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 25004
+    #node4 - node13 gets: 0.07657 * 25004
+    And the parties receive the following reward for epoch 2:
+    | party  | asset | amount |
+    | party1 | VEGA  |  99    | 
+    | node1  | VEGA  |  1916  | 
+    | node2  | VEGA  |  1919  | 
+    | node3  | VEGA  |  1921  | 
+    | node4  | VEGA  |  1914  | 
+    | node5  | VEGA  |  1914  | 
+    | node6  | VEGA  |  1914  | 
+    | node7  | VEGA  |  1914  | 
+    | node8  | VEGA  |  1914  | 
+    | node9  | VEGA  |  1914  | 
+    | node10 | VEGA  |  1914  | 
+    | node11 | VEGA  |  1914  | 
+    | node12 | VEGA  |  1914  | 
+    | node13 | VEGA  |  1914  | 
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |  50    | 
+    #advance to the beginning and end of the following epoch 
+    When the network moves ahead "7" blocks
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 3:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07698     |     0.07698      |    
+    |  node2  |      0.07813     |     0.07813      |
+    |  node3  |      0.07890     |     0.07890      | 
+    |  node4  |      0.07660     |     0.07660      |
+    #node1 has 10k self delegation +  50 from party1
+    #node2 has 10k self delegation + 200 from party1
+    #node3 has 10k self delegation + 300 from party1
+    #all other nodes have 10k self delegation
+    #party1 gets 0.07698  * 12506 * 0.883 * 50/10050 + 0.07813 * 12506 * 0.883 * 200/10200 + 0.07890 * 12506 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 50/10050)  * 0.07698 * 12506
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07813 * 12506
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07890 * 12506
+    #node4 - node13 gets: 0.07660 * 12506
+    And the parties receive the following reward for epoch 3:
+    | party  | asset | amount |
+    | party1 | VEGA  |  45    | 
+    | node1  | VEGA  |  958   | 
+    | node2  | VEGA  |  960   | 
+    | node3  | VEGA  |  961   | 
+    | node4  | VEGA  |  958   | 
+    | node5  | VEGA  |  958   | 
+    | node6  | VEGA  |  958   | 
+    | node7  | VEGA  |  958   | 
+    | node8  | VEGA  |  958   | 
+    | node9  | VEGA  |  958   | 
+    | node10 | VEGA  |  958   | 
+    | node11 | VEGA  |  958   | 
+    | node12 | VEGA  |  958   | 
+    | node13 | VEGA  |  958   | 
+  
+  Scenario: Parties get rewarded for a full epoch of having delegated stake - the reward amount is capped per participant
+   Description: Parties have had their tokens delegated to nodes for a full epoch and get rewarded for the full epoch and the reward amount per participant is capped
+  
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 100000 | 
+      
+    Given the following network parameters are set:
+      | name                                              | value |
+      | reward.staking.delegation.maxPayoutPerParticipant | 3000  |
+    #the reward amount for each participant per epoch is capped to 3k by maxPayoutPerParticipant
+    #advance to the end of the epoch
+    When the network moves ahead "7" blocks
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 1:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      | 
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party2 
+    #node3 has 10k self delegation + 300 from party3 
+    #all other nodes have 10k self delegation 
+    #party1 gets 0.07734 * 50000 * 0.883 * 100/10100 + 0.07810 * 50000 * 0.883 * 200/10200 + 0.07887 * 50000 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 50000
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 50000
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 50000
+    #node4 - node13 gets: 0.07657 * 50000
+    And the parties receive the following reward for epoch 1:
+    | party  | asset | amount |
+    | party1 | VEGA  |  201   | 
+    | node1  | VEGA  |  3000  | 
+    | node2  | VEGA  |  3000  | 
+    | node3  | VEGA  |  3000  | 
+    | node4  | VEGA  |  3000  | 
+    | node5  | VEGA  |  3000  | 
+    | node6  | VEGA  |  3000  | 
+    | node7  | VEGA  |  3000  | 
+    | node8  | VEGA  |  3000  | 
+    | node9  | VEGA  |  3000  | 
+    | node10 | VEGA  |  3000  | 
+    | node11 | VEGA  |  3000  | 
+    | node12 | VEGA  |  3000  | 
+    | node13 | VEGA  |  3000  |
+
+  Scenario: Topping up the reward account and confirming reward transfers are correctly refelected in parties account balances
+    Description: Topping up the reward account and confirming reward transfers are correctly refelected in parties account balances when they get rewarded for a full epoch of having delegated stake
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  |  50000 | 
+
+    #advance to the end of the epoch
+    When the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 1:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      | 
+    
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party2 
+    #node3 has 10k self delegation + 300 from party3 
+    #all other nodes have 10k self delegation 
+    #party1 gets 0.07734 * 25000 * 0.883 * 100/10100 + 0.07810 * 25000 * 0.883 * 200/10200 + 0.07887 * 25000 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 25000
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 25000
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 25000
+    #node4 - node13 gets: 0.07657 * 25000
+    
+    And the parties receive the following reward for epoch 1:
+    | party  | asset | amount |
+    | party1 | VEGA  |   99   | 
+    | node1  | VEGA  |  1916  | 
+    | node2  | VEGA  |  1918  | 
+    | node3  | VEGA  |  1920  | 
+    | node4  | VEGA  |  1914  | 
+    | node5  | VEGA  |  1914  | 
+    | node6  | VEGA  |  1914  | 
+    | node7  | VEGA  |  1914  | 
+    | node8  | VEGA  |  1914  | 
+    | node9  | VEGA  |  1914  | 
+    | node10 | VEGA  |  1914  | 
+    | node11 | VEGA  |  1914  | 
+    | node12 | VEGA  |  1914  | 
+    | node13 | VEGA  |  1914  | 
+
+    Then "party1" should have general account balance of "99" for asset "VEGA"
+    Then "node1" should have general account balance of "1916" for asset "VEGA"
+  
+    And the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  | 74993  | 
+
+    # The total amount now in rewards account is 100000-50000-24993(rewards payout)+74993 = 100000
+    When the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 2:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      | 
+
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party2 
+    #node3 has 10k self delegation + 300 from party3 
+    #all other nodes have 10k self delegation 
+    #party1 gets 0.07734 * 50000 * 0.883 * 100/10100 + 0.07810 * 50000 * 0.883 * 200/10200 + 0.07887 * 50000 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 50000
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 50000
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 50000
+    #node4 - node13 gets: 0.07657 * 50000
+    
+    And the parties receive the following reward for epoch 2:
+    | party  | asset | amount |
+    | party1 | VEGA  |  201   | 
+    | node1  | VEGA  |  3832  | 
+    | node2  | VEGA  |  3837  | 
+    | node3  | VEGA  |  3841  | 
+    | node4  | VEGA  |  3828  | 
+    | node5  | VEGA  |  3828  | 
+    | node6  | VEGA  |  3828  | 
+    | node8  | VEGA  |  3828  | 
+    | node10 | VEGA  |  3828  | 
+    | node11 | VEGA  |  3828  | 
+    | node12 | VEGA  |  3828  | 
+    | node13 | VEGA  |  3828  | 
+
+    Then "party1" should have general account balance of "300" for asset "VEGA"
+    Then "node1" should have general account balance of "5748" for asset "VEGA"
+
+  Scenario: Parties get the smallest reward amount of 1 when the reward pot is smallest
+    Description:  Validators get the smallest reward amount of 1 and delegator earns nothing
+    # Explanation - 1 vega is actually 1000000000000000000 so when reward account = 27 then that’s a very very very small fraction of a vega. Hence noone gets anything because the calculation is made in integers so anything that ends up being less than one is 0
+
+    Given the global reward account gets the following deposits:
+      | asset | amount |
+      | VEGA  |     28 | 
+
+    #advance to the end of the epoch
+    When the network moves ahead "7" blocks
+
+    #verify validator score 
+    Then the validators should have the following val scores for epoch 1:
+    | node id | validator score  | normalised score |
+    |  node1  |      0.07734     |     0.07734      |    
+    |  node2  |      0.07810     |     0.07810      |
+    |  node3  |      0.07887     |     0.07887      | 
+    |  node4  |      0.07657     |     0.07657      | 
+
+    #node1 has 10k self delegation + 100 from party1
+    #node2 has 10k self delegation + 200 from party2 
+    #node3 has 10k self delegation + 300 from party3 
+    #all other nodes have 10k self delegation 
+    #party1 gets 0.07734 * 28 * 0.883 * 100/10100 + 0.07810 * 28 * 0.883 * 200/10200 + 0.07887 * 28 * 0.883 * 300/10300
+    #node1 gets: (1 - 0.883 * 100/10100) * 0.07734 * 28
+    #node2 gets: (1 - 0.883 * 200/10200) * 0.07810 * 28
+    #node3 gets: (1 - 0.883 * 300/10300) * 0.07887 * 28
+    #node4 - node13 gets: 0.07657 * 28
+
+    And the parties receive the following reward for epoch 1:
+    | party  | asset | amount |
+    | party1 | VEGA  | 0 | 
+    | node1  | VEGA  | 1 | 
+    | node2  | VEGA  | 1 | 
+    | node3  | VEGA  | 1 | 
+    | node4  | VEGA  | 1 |
+    | node5  | VEGA  | 1 | 
+    | node6  | VEGA  | 1 | 
+    | node7  | VEGA  | 1 | 
+    | node8  | VEGA  | 1 | 
+    | node9  | VEGA  | 1 | 
+    | node10 | VEGA  | 1 | 
+    | node11 | VEGA  | 1 | 
+    | node12 | VEGA  | 1 | 
+    | node13 | VEGA  | 1 | 
+
+    Then "node1" should have general account balance of "1" for asset "VEGA"
+
+    When the network moves ahead "7" blocks
+
+    And the parties receive the following reward for epoch 2:
+    | party  | asset | amount |
+    | party1 | VEGA  | 0 | 
+    | node1  | VEGA  | 0 | 
+    | node2  | VEGA  | 0 | 
+    | node3  | VEGA  | 0 | 
+    | node4  | VEGA  | 0 |
+    | node5  | VEGA  | 0 | 
+    | node6  | VEGA  | 0 | 
+    | node7  | VEGA  | 0 | 
+    | node8  | VEGA  | 0 | 
+    | node9  | VEGA  | 0 | 
+    | node10 | VEGA  | 0 | 
+    | node11 | VEGA  | 0 | 
+    | node12 | VEGA  | 0 | 
+    | node13 | VEGA  | 0 | 
+
+    When the network moves ahead "37542" blocks
+    And the parties receive the following reward for epoch 3153602:
+    | party  | asset | amount |
+    | party1 | VEGA  | 0 | 
+    | node1  | VEGA  | 0 | 
+    | node2  | VEGA  | 0 | 
+    | node3  | VEGA  | 0 | 
+    | node4  | VEGA  | 0 |
+    | node5  | VEGA  | 0 | 
+    | node6  | VEGA  | 0 | 
+    | node7  | VEGA  | 0 | 
+    | node8  | VEGA  | 0 | 
+    | node9  | VEGA  | 0 | 
+    | node10 | VEGA  | 0 | 
+    | node11 | VEGA  | 0 | 
+    | node12 | VEGA  | 0 | 
+    | node13 | VEGA  | 0 | 

--- a/qa-scenarios/0061-delegation.feature
+++ b/qa-scenarios/0061-delegation.feature
@@ -1,0 +1,1213 @@
+Feature: Staking & Delegation 
+
+  Background:
+    Given the following network parameters are set:
+      | name                                              | value  |
+      | reward.asset                                      | VEGA   |
+      | validators.epoch.length                           | 10s    |
+      | validators.delegation.minAmount                   | 10     |
+      | reward.staking.delegation.payoutDelay             |  0s    |
+      | reward.staking.delegation.delegatorShare          |  0.883 |
+      | reward.staking.delegation.minimumValidatorStake   |  100   |
+      | reward.staking.delegation.payoutFraction          |  0.5   |
+      | reward.staking.delegation.maxPayoutPerParticipant | 100000 |
+      | reward.staking.delegation.competitionLevel        |  1.1   |
+      | reward.staking.delegation.maxPayoutPerEpoch       |  50000 |
+
+
+    Given time is updated to "2021-08-26T00:00:00Z"
+    Given the average block duration is "2"
+
+    And the validators:
+      | id     | staking account balance |
+      | node1  |         1000000         |
+      | node2  |         1000000         |
+      | node3  |         1000000         |
+      | node4  |         1000000         |
+      | node5  |         1000000         |
+      | node6  |         1000000         |
+      | node7  |         1000000         |
+      | node8  |         1000000         |
+      | node9  |         1000000         |
+      | node10 |         1000000         |
+      | node11 |         1000000         |
+      | node12 |         1000000         |
+      | node13 |         1000000         |
+
+    #set up the self delegation of the validators
+    Then the parties submit the following delegations:
+      | party  | node id  | amount |
+      | node1  |  node1   | 10000  | 
+      | node2  |  node2   | 10000  |       
+      | node3  |  node3   | 10000  | 
+      | node4  |  node4   | 10000  | 
+      | node5  |  node5   | 10000  | 
+      | node6  |  node6   | 10000  | 
+      | node7  |  node7   | 10000  | 
+      | node8  |  node8   | 10000  | 
+      | node9  |  node9   | 10000  | 
+      | node10 |  node10  | 10000  | 
+      | node11 |  node11  | 10000  | 
+      | node12 |  node12  | 10000  | 
+      | node13 |  node13  | 10000  | 
+
+    And the parties deposit on staking account the following amount:  
+      | party  | asset  | amount |
+      | party1 | VEGA   | 10000  |
+
+    #complete the first epoch for the self delegation to take effect
+    Then the network moves ahead "7" blocks
+
+  Scenario: A party can delegate to a validator and undelegate at the end of an epoch
+    Description: A party with a balance in the staking account can delegate to a validator
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  100   | 
+    | party1 |  node2   |  200   |       
+    | party1 |  node3   |  300   |   
+    
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 100   | 
+    | party1 |  node2   | 200   |       
+    | party1 |  node3   | 300   |        
+
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 100    | 
+    | party1 |  node2   | 200    |       
+    | party1 |  node3   | 300    |   
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |      when     |
+    | party1 |  node1   |  100   |  end of epoch |
+    | party1 |  node2   |  200   |  end of epoch |              
+    | party1 |  node3   |  300   |  end of epoch |           
+
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 100    | 
+    | party1 |  node2   | 200    |       
+    | party1 |  node3   | 300    |   
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |   
+
+    #advance to the end of epoch for the undelegation to take place 
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |   
+
+  Scenario: A party cannot delegate less than minimum delegateable stake  
+    Description: A party attempts to delegate less than minimum delegateable stake from its staking account to a validator minimum delegateable stake
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount | reference | error                                                                             |
+    | party1 |  node1   |    1   |      a    | delegation amount is lower than the minimum amount for delegation for a validator |
+    | party1 |  node2   |    2   |      b    | delegation amount is lower than the minimum amount for delegation for a validator |    
+    | party1 |  node3   |    3   |      c    | delegation amount is lower than the minimum amount for delegation for a validator |
+
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |    0   | 
+    | party1 |  node2   |    0   |       
+    | party1 |  node3   |    0   |        
+
+  Scenario: A party cannot delegate more than it has in staking account
+    Description: A party attempts to delegate more than it has in its staking account to a validator
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount   | reference | error                               |
+    | party1 |  node1   |    10001   |      a    | insufficient balance for delegation |
+    | party1 |  node2   |    10002   |      b    | insufficient balance for delegation |    
+    | party1 |  node3   |    10003   |      c    | insufficient balance for delegation |
+
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |    0   | 
+    | party1 |  node2   |    0   |       
+    | party1 |  node3   |    0   |        
+
+  Scenario: A party cannot cumulatively delegate more than it has in staking account
+    
+    When the parties submit the following delegations:
+    | party  | node id  |   amount   | reference | error                               |
+    | party1 |  node1   |     5000   |           |                                     |
+    | party1 |  node2   |     5001   |      a    | insufficient balance for delegation |
+
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |   5000 | 
+    | party1 |  node2   |    0   |       
+    | party1 |  node3   |    0   |        
+  
+  Scenario: A party cannot delegate stake size such that it exceeds maximum amount of stake for a validator
+    Description: A party attempts to delegate token stake which exceed maximum stake for a validator
+
+    #epoch1 started
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node1   |    1500   | 
+    | party1 |  node2   |    2000   | 
+    | party1 |  node3   |    2500   | 
+
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party1 |  node3   | 2500   |        
+
+    #however when the epoch ends and the delegations are processed the max allowed delegation per node is calculated as 
+    #roughly 1.1/13 * (13 * 10000 + 1500 + 2000 + 2500) =  ~101507 which means each node will only accept max delegation of ~1507 (on top of 10k self delegation)
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 1507   |       
+    | party1 |  node3   | 1507   | 
+
+    Then the network moves ahead "7" blocks
+    
+    # amounts remain constant even as total delegated amount changes (due to application of the cap)
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 1507   |       
+    | party1 |  node3   | 1507   | 
+
+    Then the network moves ahead "1" blocks
+
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |     when     |
+    | party1 |  node1   |  500   | end of epoch | 
+    | party1 |  node2   |  500   | end of epoch |     
+    | party1 |  node3   |  500   | end of epoch | 
+
+    Then the network moves ahead "6" blocks
+
+    Then the parties should have the following delegation balances for epoch 4:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1000   | 
+    | party1 |  node2   | 1007   |       
+    | party1 |  node3   | 1007   | 
+
+    Then the network moves ahead "14" blocks
+
+    Then the parties should have the following delegation balances for epoch 6:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1000   | 
+    | party1 |  node2   | 1007   |       
+    | party1 |  node3   | 1007   | 
+
+    And the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node4   |    2000   | 
+
+    And the network moves ahead "1" blocks
+
+    Then the parties should have the following delegation balances for epoch 7:
+    | party  | node id  | amount |
+    | party1 |  node4   | 2000   |   
+
+    When the network moves ahead "6" blocks
+
+    #Given stakes of 1000, 1007, 1007 & 2000 I expect the new max delegation of about 1424
+    Then the parties should have the following delegation balances for epoch 7:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1000   | 
+    | party1 |  node2   | 1007   |       
+    | party1 |  node3   | 1007   |   
+    | party1 |  node4   | 1424   |   
+
+  Scenario: Maximum amount of stake for a validator is not affected by delegations/undelegations that net each other
+    Description: Expecting same result as above despite multiple delegations/undelegations
+
+    #epoch1 started
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node1   |    1500   | 
+    | party1 |  node2   |    2000   | 
+    | party1 |  node3   |    2500   | 
+    | party1 |  node3   |    2500   | 
+
+    When the network moves ahead "1" blocks
+
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |  when         |
+    | party1 |  node3   |  500   |  now          |      
+    | party1 |  node3   |  500   |  now          |      
+    | party1 |  node3   |  500   |  now          |      
+    | party1 |  node3   |  500   |  now          |      
+    | party1 |  node3   |  500   |  end of epoch |    
+
+    When the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node2   |    1000   |   
+
+    When the network moves ahead "1" blocks
+
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |  when     |
+    | party1 |  node2   |  500   |  now      |    
+
+    When the network moves ahead "1" blocks  
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |  when         |
+    | party1 |  node2   |  500   |  end of epoch | 
+
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party1 |  node3   | 2500   |        
+
+    When the network moves ahead "3" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 1507   |       
+    | party1 |  node3   | 1507   |   
+
+  Scenario: Maximum amount of stake for a validator increased by delegations that cannot be met at epoch end due to insufficient token balance after a withdrawal.
+
+    And the parties deposit on staking account the following amount:  
+    | party  | asset  | amount |
+    | party2 | VEGA   | 10000  |
+
+    #epoch1 started
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node1   |    1500   | 
+    | party1 |  node2   |    2000   | 
+    | party2 |  node3   |    2500   | 
+
+    When the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party2 |  node3   |    2500   | 
+
+    When the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party2 |  node3   |    2500   |  
+
+    When the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party2 |  node3   |    2500   | 
+
+    When the network moves ahead "1" blocks  
+
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party2 | VEGA   |  7500  |
+
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party2 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party2 |  node3   | 10000  |        
+
+    When the network moves ahead "3" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party2 |  node3   | 2142   |
+
+    When the network moves ahead "1" blocks
+
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party2 | VEGA   |   500  |
+
+    When the network moves ahead "1" blocks
+
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party2 |  node3   | 2142   |
+
+    When the network moves ahead "7" blocks
+
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party2 |  node3   | 2000   |
+
+  Scenario: Maximum amount of stake for a validator is not affected by delegations/undelegations that net each other
+    Description: Expecting same result as above despite multiple delegations/undelegations
+
+    #epoch1 started
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node1   |    1500   | 
+    | party1 |  node2   |    2000   | 
+    | party1 |  node3   |    2500   | 
+    | party1 |  node3   |    2500   | 
+
+    When the network moves ahead "1" blocks
+
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |  when         |
+    | party1 |  node3   |  500   |  now          |      
+    | party1 |  node3   |  500   |  now          |      
+    | party1 |  node3   |  500   |  now          |      
+    | party1 |  node3   |  500   |  now          |      
+    | party1 |  node3   |  500   |  end of epoch |    
+
+    When the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node2   |    1000   |   
+
+    When the network moves ahead "1" blocks
+
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |  when     |
+    | party1 |  node2   |  500   |  now      |    
+
+    When the network moves ahead "1" blocks  
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |  when         |
+    | party1 |  node2   |  500   |  end of epoch | 
+
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party1 |  node3   | 2500   |        
+
+    When the network moves ahead "3" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 1507   |       
+    | party1 |  node3   | 1507   |   
+
+  Scenario: Maximum amount of stake for a validator increased by delegations that cannot be met at epoch end due to insufficient token balance after a withdrawal.
+
+    And the parties deposit on staking account the following amount:  
+    | party  | asset  | amount |
+    | party2 | VEGA   | 10000  |
+
+    #epoch1 started
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node1   |    1500   | 
+    | party1 |  node2   |    2000   | 
+    | party2 |  node3   |    2500   | 
+
+    When the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party2 |  node3   |    2500   | 
+
+    When the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party2 |  node3   |    2500   |  
+
+    When the network moves ahead "1" blocks
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party2 |  node3   |    2500   | 
+
+    When the network moves ahead "1" blocks  
+
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party2 | VEGA   |  7500  |
+
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party2 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party2 |  node3   | 10000  |        
+
+    When the network moves ahead "3" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party2 |  node3   | 2142   |
+
+    When the network moves ahead "1" blocks
+
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party2 | VEGA   |   500  |
+
+    When the network moves ahead "1" blocks
+
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party2 |  node3   | 2142   |
+
+    When the network moves ahead "7" blocks
+
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party2 |  node3   | 2000   |
+
+  Scenario: A party changes delegation from one validator to another in the same epoch
+    Description: A party can change delegatation from one Validator to another
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node1   |    100   | 
+    | party1 |  node2   |    100   | 
+    | party1 |  node3   |    100   | 
+
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 100   | 
+    | party1 |  node2   | 100   |       
+    | party1 |  node3   | 100   |        
+
+    #advance to the end of the epoch for the delegation to become effective
+    When the network moves ahead "7" blocks    
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 100    | 
+    | party1 |  node2   | 100    |       
+    | party1 |  node3   | 100    |   
+
+    #start epoch 2
+    #now request to undelegate from node2 and node3 
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |      when     |
+    | party1 |  node2   |  80    |  end of epoch |     
+    | party1 |  node3   |  90    |  end of epoch | 
+
+    Then the parties submit the following delegations:
+    | party  | node id  |  amount | 
+    | party1 |  node1   |    80   | 
+    | party1 |  node1   |    90   | 
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   | 270    | 
+    | party1 |  node2   | 20     |       
+    | party1 |  node3   | 10     |   
+
+    #advance to the end of the epoch for the delegation to become effective
+    When the network moves ahead "7" blocks 
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   | 270    | 
+    | party1 |  node2   | 20     |       
+    | party1 |  node3   | 10     | 
+
+  Scenario: A party cannot delegate to an unknown node 
+    Description: A party should fail in trying to delegate to a non existing node
+
+    When the parties submit the following delegations:
+    | party  | node id   |   amount | reference | error           |
+    | party1 |  unknown1 |    100   |      a    | invalid node ID |
+    | party1 |  unknonw2 |    200   |      b    | invalid node ID |    
+
+  Scenario: A party cannot undelegate from an unknown node
+    Description: A party should fail in trying to undelegate from a non existing node
+
+    When the parties submit the following undelegations:
+    | party  | node id   |   amount |     when     | reference | error           |
+    | party1 |  unknown1 |    100   | end of epoch |      a    | invalid node ID |
+    | party1 |  unknonw2 |    200   | end of epoch |      b    | invalid node ID |     
+
+    Scenario: A party cannot delegate more than their staking account balance considering all active and pending delegation 
+    Description: A party has pending delegations and is trying to exceed their stake account balance delegation, 
+    i.e. the balance of their pending delegation + requested delegation exceeds stake account balance
+  
+    When the parties submit the following delegations:
+    | party  | node id  |  amount | reference | error                               |
+    | party1 |  node1   |   5000  |           |                                     |
+    | party1 |  node2   |   6000  |     a     | insufficient balance for delegation |    
+
+    #advance to the end of the epoch
+    When the network moves ahead "7" blocks    
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1423   | 
+
+    #party1 already have 1423 delegated so they can only theoretically delegate 10000-1423 = 8577
+    Then the parties submit the following delegations:
+    | party  | node id  |  amount | reference | error                               |
+    | party1 |  node2   |   1000  |           |                                     |    
+    | party1 |  node2   |   7578  |     a     | insufficient balance for delegation |     
+
+  Scenario: A party cannot delegate more than their staking account balance considering all active and pending undelegation 
+    Description: A party has pending delegations and undelegations and is trying to exceed their stake account balance delegation, 
+    i.e. the balance of their pending delegation + requested delegation exceeds stake account balance
+    
+    When the parties submit the following delegations:
+    | party  | node id  |  amount | reference | error                               |
+    | party1 |  node1   |   5000  |           |                                     |
+
+    #advance to the end of the epoch
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1423   | 
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |    when      |
+    | party1 |  node1   |  1000  | end of epoch |
+
+    #party1 already have 423 delegated so they can only theoretically delegate 10000-423 = 9577
+    Then the parties submit the following delegations:
+    | party  | node id  |  amount | reference | error                               |
+    | party1 |  node2   |   1000  |           |                                     |    
+    | party1 |  node2   |   8578  |     a     | insufficient balance for delegation |    
+
+  Scenario: A party can request delegate and undelegate from the same node at the same epoch such that the request can balance each other without affecting the actual delegate balance    Description: party requests to delegate to node1 at the end of the epoch and regrets it and undelegate the whole amount to delegate it to node2
+  
+    When the parties submit the following delegations:
+    | party  | node id  |  amount | 
+    | party1 |  node1   |   1000  | 
+
+    And the parties submit the following undelegations:
+    | party  | node id  | amount |    when      |
+    | party1 |  node1   |  1000  | end of epoch |
+
+    And the parties submit the following delegations:
+    | party  | node id  |  amount | 
+    | party1 |  node2   |   1000  | 
+
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 0      | 
+    | party1 |  node2   | 1000   | 
+    
+    Scenario: A party has active delegations and submits an undelegate request followed by a delegation request that covers only part of the undelegation such that the undelegation still takes place
+    Description: A party delegated tokens to node1 at previous epoch such that the delegations is now active and is requesting to undelegate some of the tokens at the end of the current epoch. Then regret some of it and submit a delegation request that undoes some of the undelegation but still some of it remains. 
+
+    When the parties submit the following delegations:
+    | party  | node id  |  amount | 
+    | party1 |  node1   |   1000  | 
+
+    When the network moves ahead "7" blocks
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |    when      |
+    | party1 |  node1   |  1000  | end of epoch |
+
+    And the parties submit the following delegations:
+    | party  | node id  |  amount | 
+    | party1 |  node1   |   100   |
+
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   | 100    | 
+
+  Scenario: A party cannot undelegate more than the delegated balance 
+    Description: A party trying to undeleagte from a node more than the amount that was delegated to it should fail 
+
+    And the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  100   | 
+    | party1 |  node2   |  200   |       
+    | party1 |  node3   |  300   |   
+
+    #advance to the beginning of the next epoch 
+    When the network moves ahead "7" blocks
+
+    Then the parties submit the following undelegations:
+    | party  | node id   |   amount |     when     | reference | error                                    |
+    | party1 |  node1    |    101   | end of epoch |      a    | incorrect token amount for undelegation  |
+    | party1 |  node2    |    201   | end of epoch |      b    | incorrect token amount for undelegation  |    
+    | party1 |  node3    |    301   | end of epoch |      c    | incorrect token amount for undelegation  |    
+    | party1 |  node1    |    100   | end of epoch |           |                                          |
+    | party1 |  node2    |    200   | end of epoch |           |                                          |    
+    | party1 |  node3    |    300   | end of epoch |           |                                          |  
+
+Scenario: A node can self delegate to itself and undelegate at the end of an epoch
+    Description: A node with a balance in the staking account can delegate to itself
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | node1   |  node1   |  1000  | 
+    
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | node1  |  node1   |  10000 | 
+        
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | node1  |  node1   | 11000  | 
+    
+    When the network moves ahead "7" blocks   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | node1 |  node1   | 11000  | 
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |    when      |
+    | node1  |  node1   |  5000  | end of epoch |
+    
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | node1  |  node1   | 11000  | 
+    
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | node1  |  node1   |  6000  | 
+    
+    #advance to the end of epoch for the undelegation to take place 
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | node1  |  node1   |  6000  | 
+      
+  Scenario: A party can undelegate all of their stake at the end of the epoch
+    Description: A with delegated stake and pending delegation can request to undelegate all. This will be translated to undelegating all the stake they have at the time and will be executed at the end of the epoch
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks    
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    Then the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1  |  node1   |  50   | 
+    | party1  |  node2   |  123  | 
+    
+    #we are in the middle of epoch2 and the party1 requests to undelegate all of their stake to party1
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |    when      |
+    | party1 |  node1   |  0     | end of epoch |
+
+    #therefore we expect their expected balance for epoch 3 for party1 node1 is 0
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    |
+    | party1 |  node2   |   123  |  
+    
+    #advance to the end of epoch2 for the delegations/undelegations to be applied
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   123  |    
+
+Scenario: A party can request to undelegate their stake or part of it right now
+    Description: A party with delegated stake and/or pending delegation can request to undelegate all or part of it immediately as opposed to at the end of the epoch
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks 
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    Then the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1  |  node1   |  50   | 
+    | party1  |  node2   |  123  | 
+    
+    #we are in the middle of epoch2 and the party1 requests to undelegate all of their stake to party1
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |  when  |
+    | party1 |  node1   |  0     |  now   |
+
+    #therefore we expect their current balance for epoch 2 for party1 node1 is 0
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    |
+    | party1 |  node2   |   0    |
+    
+    #the expected balance for the following epoch should be the same for party1/node1 because undelegation has already been applied and for party1/node1 should include the expected delegation
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    |
+    | party1 |  node2   |  123   |
+
+    #advance to the end of epoch2 for the delegations/undelegations to be applied - and expect no change for node1 because undelegation has already taken place
+    #the delegation from party1 to node2 will have been applied 
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   123  |  
+  
+  Scenario: A party withdraws from their staking account during an epoch - their stake is being undelegated automatically to match the difference
+    Description: A party with delegated stake withdraws from their staking account during an epoch - at the end of the epoch when delegations are processed the party will be forced to undelegate the difference between the stake they have delegated and their staking account balance. 
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9500  |
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks
+    # we expect the actual balance of epoch 2 for party1 has changed retrospectively to 500 to reflect that the party has insufficient balance in their staking account to cover 1000 delegated tokens   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  500   |   
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |  500   |
+
+  Scenario: Undelegate now followed by withdraw - same behaviour as either underlegate now or withdraw
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |  when  |
+    | party1 |  node1   |  500   |  now   |
+
+    # start epoch2    
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9600  |
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  400   |   
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |  400   |     
+
+Scenario: Withdrawal followed by undelegate now (same epoch) - same behaviour as either underlegate now or withdraw
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    # start epoch2
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9500  |
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |  when  |
+    | party1 |  node1   |    400 |  now   |
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |    500 |   
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |    500 |    
+
+  Scenario: Withdrawal followed by undelegate now (next epoch) - results in additional undelegation
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks 
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9500  |
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |    500 |   
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |  when  |
+    | party1 |  node1   |    200 |  now   |
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |    300 |
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount |  when  |
+    | party1 |  node1   |    200 |  now   |
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |    100 |    
+
+    When the network moves ahead "7" blocks
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |    100 |    
+
+  Scenario: Mix undelegate now & end of epoch
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount | when         |
+    | party1 |  node1   |    500 | now          |
+    | party1 |  node1   |    400 | end of epoch |
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks
+    # we expect the actual balance of epoch 2 for party1 has changed retrospectively to 500 to reflect that the party has insufficient balance in their staking account to cover 1000 delegated tokens   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |    500 |   
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |    100 |    
+
+    When the network moves ahead "7" blocks
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |    100 |    
+
+  Scenario: A validator gets past maximum stake by changing network parameter
+    Description: A party attempts to delegate token stake which exceed maximum stake for a validator
+
+    When the parties submit the following delegations:
+    | party  | node id  |   amount  | 
+    | party1 |  node1   |    1500   | 
+    | party1 |  node2   |    2000   | 
+    | party1 |  node3   |    2500   | 
+
+    #we are now in epoch 1 so the delegation balance for epoch 1 should not include the delegation but the hypothetical balance for epoch 2 should 
+    Then the parties should have the following delegation balances for epoch 1:
+    | party  | node id  | amount |
+    | party1 |  node1   |   0    | 
+    | party1 |  node2   |   0    |       
+    | party1 |  node3   |   0    |        
+
+    And the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 2000   |       
+    | party1 |  node3   | 2500   |        
+
+    #however when the epoch ends and the delegations are processed the max allowed delegation per node is calculated as 
+    #roughly 1.3/13 * (13 * 10000 + 1000 + 2000 + 3000) =  ~1507 which means each node will only accept max delegation of ~1507
+    When the network moves ahead "7" blocks 
+
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1500   | 
+    | party1 |  node2   | 1507   |       
+    | party1 |  node3   | 1507   |   
+
+    Given the following network parameters are set:
+      | name                                            | value |
+      | reward.staking.delegation.competitionLevel      | 1.01  |
+
+     When the network moves ahead "7" blocks   
+
+     # The new expected limit is 566, but a drop in limit doesn't trigger undelegation hence expecting old delegation values.
+     Then the parties should have the following delegation balances for epoch 3:
+      | party  | node id  | amount |
+      | party1 |  node1   | 1500   | 
+      | party1 |  node2   | 1507   |       
+      | party1 |  node3   | 1507   |   
+
+     Given the following network parameters are set:
+      | name                                            | value |
+      | reward.staking.delegation.competitionLevel      | 1.2   |
+
+    When the network moves ahead "7" blocks   
+
+     # Changing the competitionLevel raises the max delegation limit, however not expecting more delegation to automatically get deployed.
+     Then the parties should have the following delegation balances for epoch 4:
+      | party  | node id  | amount |
+      | party1 |  node1   | 1500   | 
+      | party1 |  node2   | 1507   |       
+      | party1 |  node3   | 1507   |   
+
+
+    When the parties submit the following delegations:
+      | party  | node id  |   amount  | 
+      | party1 |  node1   |    1000   | 
+      | party1 |  node2   |     500   | 
+      | party1 |  node3   |    2200   | 
+
+    When the network moves ahead "1" blocks
+  
+    # Given new delegations the new expected limit is 2758, however not expecting to see it reflected in delegation balances until epoch ends
+    Then the parties should have the following delegation balances for epoch 5:
+      | party  | node id  | amount |
+      | party1 |  node1   | 2500   | 
+      | party1 |  node2   | 2007   |       
+      | party1 |  node3   | 3707   |   
+
+    When the network moves ahead "6" blocks
+
+    Then the parties should have the following delegation balances for epoch 5:
+      | party  | node id  | amount |
+      | party1 |  node1   | 2500   | 
+      | party1 |  node2   | 2007   |       
+      | party1 |  node3   | 2758   |
+
+  Scenario: A party undelegates now and then withdraws from their staking account during an epoch - their stake is being undelegated automatically to match the difference
+    Description: A party undelegates now and then withdraws from their staking account during an epoch - then immediately delegations are processed the party will be forced to undelegate the difference between the stake they have delegated and their staking account balance. 
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1000   | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1000   | 
+  
+    Then the parties submit the following undelegations:
+    | party  | node id  | amount | when |
+    | party1 |  node1   |  500   | now  |
+
+    And the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9600  |
+
+    And the parties should have the following staking account balances:
+    | party  | asset | amount |
+    | party1 | VEGA  | 400    |  
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks  
+    # we expect the actual balance of epoch 2 for party1 has changed retrospectively to 400 to reflect that the party has insufficient balance in their staking account to cover 1000-500 delegated tokens   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  400   | 
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |  400   |     
+
+  Scenario: A party delegates and then withdraws from their staking account during the same epoch such that delegation is a successful
+    Description: A party delegates now and then withdraws from their staking account during the same epoch such that delegation is a successful
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1000   | 
+
+    And the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9000  |
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks      
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1000   | 
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks   
+    # we expect the actual balance of epoch 2 for party1 to be upated to 500 to reflect that the party has sufficient balance in their staking account to cover 1000 delegated tokens   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  |   
+
+     And the parties should have the following staking account balances:
+    | party  | asset | amount |
+    | party1 | VEGA  | 1000   |  
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  |     
+
+  Scenario: A party delegates and then withdraws from their staking account during the same epoch such that delegation fails
+    Description: A party delegates now and then withdraws from their staking account during the same epoch such that delegation fails
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   | 1000   | 
+
+    And the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9500  |
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks   
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   | 0      | 
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks   
+    # we expect the actual balance of epoch 2 for party1 has changed retrospectively to 0 to reflect that the party has insufficient balance in their staking account to cover 1000 delegated tokens    
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  0     |   
+
+     And the parties should have the following staking account balances:
+    | party  | asset | amount |
+    | party1 | VEGA  | 500    |  
+
+    And the parties should have the following delegation balances for epoch 3:
+    | party  | node id  | amount |
+    | party1 |  node1   |  0     |    
+
+  Scenario: A party withdraws from their staking account during an epoch - their stake is being undelegated automatically to match the difference
+    Description: A party with delegated stake withdraws from their staking account during an epoch - at the end of the epoch when delegations are processed the party will be forced to undelegate the difference between the stake they have delegated and their staking account balance. 
+
+    When the parties submit the following delegations:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    #end epoch 1 for the delegation to take effect   
+    When the network moves ahead "7" blocks      
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  1000  | 
+
+    And the parties should have the following staking account balances:
+    | party  | asset | amount |
+    | party1 | VEGA  | 10000  |   
+
+    Given the parties withdraw from staking account the following amount:  
+    | party  | asset  | amount |
+    | party1 | VEGA   |  9500  |
+
+    And the parties submit the following undelegations:
+    | party  | node id  | amount | when |
+    | party1 |  node1   |  1000  | now  |    
+
+    # advance to the end of epoch2
+    When the network moves ahead "7" blocks   
+    # we expect the actual balance of epoch 2 for party1 has changed retrospectively to 0 to reflect that the 500 tokens have undelegated too
+    Then the parties should have the following delegation balances for epoch 2:
+    | party  | node id  | amount |
+    | party1 |  node1   |  0     |  
+
+    And the parties should have the following staking account balances:
+    | party  | asset | amount |
+    | party1 | VEGA  | 500    |


### PR DESCRIPTION
Copy staking and delegation feature tests from `vega` repo. 

@Vegaklaus I believe these cover most of the test cases outlined by you in https://github.com/vegaprotocol/specs-internal/issues/680 apart from:

4. The number of validators becomes lower than minval - **number of validators is fixed for now**
5. Every block in that epoch is full of delegation/undelegation commands -**covered with ***some*** delegations/undelegations, that's all that can be sensibly done via an integration test I think**.  

Closes https://github.com/vegaprotocol/specs-internal/issues/680