### PR TITLE
Add target stake calc clarification

### DIFF
--- a/protocol/0041-target-stake.md
+++ b/protocol/0041-target-stake.md
@@ -10,7 +10,7 @@ The parameter c_1 is a market parameter (with network parameter `market.liquidit
 ## Definitions / Parameters used
 - **Open interest**: the volume of all open positions in a given market.
 - `target_stake_time_window` is a market parameter (with network parameter `market.stake.target.timeWindow` giving a default value) defining the length of window over which we measure open interest (see below). This should be measured in seconds and a typical value is one week i.e. `7 x 24 x 3600` seconds.
-- Co(v)erage `target_stake_scaling_factor` is a market parameter (with network paramter `market.stake.target.scalingFactor` giving a default value) defining scaling between liquidity demand estimate based on open interest and target stake.
+- `target_stake_scaling_factor` is a market parameter (with network paramter `market.stake.target.scalingFactor` giving a default value) defining scaling between liquidity demand estimate based on open interest and target stake.
 - `risk_factor_short`, `risk_factor_long` are the market risk factors, see `0018-quant-risk-models.ipynb`. 
 - `mark_price`, see [mark price](0009-mark-price.md) spec.
 - `indicative_uncrossing_price`, see [auction](0026-auctions.md) spec.

--- a/protocol/0041-target-stake.md
+++ b/protocol/0041-target-stake.md
@@ -1,6 +1,6 @@
 # Target stake
 
-This spec outlines how to measure how much stake we want committed to a market relative to what is happening on the market (currently open interest). 
+This spec outlines how to measure how much stake we want committed to a market relative to what is happening on the market (currently open interest).
 The target stake is a calculated quantity, utilised by various mechanisms in the protocol:
 
 - If the LPs total committed stake is less than c_1 x `target_stake` we trigger liquidity auction. See [Liquidity Monitoring](./0035-liquidity-monitoring.md). Note that there is a one-to-one correspondence between the amount of stake LPs committed and the supplied liquidity. 
@@ -9,10 +9,11 @@ The parameter c_1 is a market parameter (with network parameter `market.liquidit
 
 ## Definitions / Parameters used
 - **Open interest**: the volume of all open positions in a given market.
-- `target_stake_time_window` is a market parameter (with network parameter `market.stake.target.timeWindow` giving a default value) defining the length of window over which we measure open interest (see below). This should be measured in seconds and a typical value is one week i.e. `7 x 24 x 3600` seconds. 
+- `target_stake_time_window` is a market parameter (with network parameter `market.stake.target.timeWindow` giving a default value) defining the length of window over which we measure open interest (see below). This should be measured in seconds and a typical value is one week i.e. `7 x 24 x 3600` seconds.
 - Co(v)erage `target_stake_scaling_factor` is a market parameter (with network paramter `market.stake.target.scalingFactor` giving a default value) defining scaling between liquidity demand estimate based on open interest and target stake.
 - `risk_factor_short`, `risk_factor_long` are the market risk factors, see `0018-quant-risk-models.ipynb`. 
-- `mark_price`, see [mark price](0009-mark-price.md) spec. 
+- `mark_price`, see [mark price](0009-mark-price.md) spec.
+- `indicative_uncrossing_price`, see [auction](0026-auctions.md) spec.
 
 
 ### Current definitions
@@ -40,10 +41,10 @@ Example 2: As above but the market opened at `t_0 = 4:15`. Then `t_window = [4:1
 
 From `max_oi` we calculate 
 
-`target_stake = mark_price x max_oi x target_stake_scaling_factor x rf`,
+`target_stake = reference_price x max_oi x target_stake_scaling_factor x rf`,
 
-where `rf = max(risk_factor_short, risk_factor_long)`. Note that currently we always have that `risk_factor_short >= risk_factor_long` but this could change once we go beyond futures... so safer to take a `max`.
-Note that the units of `target_stake` are the settlement currency of the market as those are the units of the `mark_price`. 
+where `reference_price` is `mark_price` when market is in continuous trading mode and `indicative_uncrossing_price` during auctions, and `rf = max(risk_factor_short, risk_factor_long)`. Note that currently we always have that `risk_factor_short >= risk_factor_long` but this could change once we go beyond futures... so safer to take a `max`.
+Note that the units of `target_stake` are the settlement currency of the market as those are the units of the `reference_price`.
 
 Example 3: if `target_stake_scaling_factor = 10`, `rf = 0.004` and `max_oi = 120` then `target_stake = 4.8`.
 


### PR DESCRIPTION
Target stake calculation: use indicative uncrossing price whilst in auction.