### PR TITLE
Document current settlement at expiry oracle behaviour

### DIFF
--- a/protocol/0016-product-builtin-future.md
+++ b/protocol/0016-product-builtin-future.md
@@ -48,6 +48,7 @@ cash_settled_future.settlement_data(event) {
 
 	// Suspend the market if we receive settlement data before trading termination
 	// this would require investigation and governance action
+	// MVP version: If settlement data was received prior to trading termination use the last value received, otherwise use the first value received after trading is terminated 
 	if market.status != TRADING_TERMINATED {
 		setMarketStatus(SUSPENDED)
 		return


### PR DESCRIPTION
**MVP behaviour (current)**: If settlement data was received prior to trading termination use the last value received, otherwise use the first value received after trading is terminated 
**Desired behaviour**: Suspend the market if we receive settlement data before trading termination this would require investigation and governance action