### PR TITLE
Add earnerd but delayed rewards to LNL checkpoint

### DIFF
--- a/non-protocol-specs/0005-limited-network-life.md
+++ b/non-protocol-specs/0005-limited-network-life.md
@@ -32,7 +32,9 @@ Information to store:
 - All [asset proposals](../protocol/0028-governance.md) that have been *accepted*.
 - All delegation info.
 - On chain treasury balances and on-chain reward functions / parameters (for 💧 Sweetwater this is only the network params that govern [Staking and delegation](../protocol/0057-reward-functions.md) ).
+- All reward balances accrued by all parties but not yet transferred to their general account due to payout delays.
 - [Account balances](../protocol/0013-accounts.md) for all parties per asset: sum of general, margin and LP bond accounts. See exception below about signed-for-withdrawal. Does *not* include the "staking" account balance.
+- Fee pools: Fees are paid into per market or per asset pools and distributed periodically. 
 - Event ID of the last processed deposit event for all bridged chains
 - Withdrawal transaction bundles for all bridged chains for all ongoing withdrawals (parties with non-zero "signed-for-withdrawal" balances)
 - hash of the previous block, block number and transaction id of the block from which the snapshot is derived


### PR DESCRIPTION
We were incorrectly not storing earned but delayed rewards in LNL checkpoint.  