### PR TITLE
Add Acceptance Criteria codes to a feature

### DIFF
--- a/qa-scenarios/0061-delegation.feature
+++ b/qa-scenarios/0061-delegation.feature
@@ -60,7 +60,7 @@ Feature: Staking & Delegation
     #complete the first epoch for the self delegation to take effect
     Then the network moves ahead "7" blocks
 
-  Scenario: A party can delegate to a validator and undelegate at the end of an epoch
+  Scenario: A party can delegate to a validator and undelegate at the end of an epoch (0059-STKG-002, 0059-STKG-013, 0059-STKG-014)
     Description: A party with a balance in the staking account can delegate to a validator
 
     When the parties submit the following delegations:
@@ -115,7 +115,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |   0    |       
     | party1 |  node3   |   0    |   
 
-  Scenario: A party cannot delegate less than minimum delegateable stake  
+  Scenario: A party cannot delegate less than minimum delegateable stake (0059-STKG-001)
     Description: A party attempts to delegate less than minimum delegateable stake from its staking account to a validator minimum delegateable stake
 
     When the parties submit the following delegations:
@@ -137,7 +137,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |    0   |       
     | party1 |  node3   |    0   |        
 
-  Scenario: A party cannot delegate more than it has in staking account
+  Scenario: A party cannot delegate more than it has in staking account (0059-STKG-unmapped)
     Description: A party attempts to delegate more than it has in its staking account to a validator
 
     When the parties submit the following delegations:
@@ -159,7 +159,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |    0   |       
     | party1 |  node3   |    0   |        
 
-  Scenario: A party cannot cumulatively delegate more than it has in staking account
+  Scenario: A party cannot cumulatively delegate more than it has in staking account (0059-STKG-unmapped)
     
     When the parties submit the following delegations:
     | party  | node id  |   amount   | reference | error                               |
@@ -178,7 +178,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |    0   |       
     | party1 |  node3   |    0   |        
   
-  Scenario: A party changes delegation from one validator to another in the same epoch
+  Scenario: A party changes delegation from one validator to another in the same epoch (0059-STKG-014)
     Description: A party can change delegatation from one Validator to another
 
     When the parties submit the following delegations:
@@ -227,7 +227,7 @@ Feature: Staking & Delegation
     | party1 |  node2   | 20     |       
     | party1 |  node3   | 10     | 
 
-  Scenario: A party cannot delegate to an unknown node 
+  Scenario: A party cannot delegate to an unknown node (0059-STKG-unmapped)
     Description: A party should fail in trying to delegate to a non existing node
 
     When the parties submit the following delegations:
@@ -235,7 +235,7 @@ Feature: Staking & Delegation
     | party1 |  unknown1 |    100   |      a    | invalid node ID |
     | party1 |  unknonw2 |    200   |      b    | invalid node ID |    
 
-  Scenario: A party cannot undelegate from an unknown node
+  Scenario: A party cannot undelegate from an unknown node (0059-STKG-unmapped)
     Description: A party should fail in trying to undelegate from a non existing node
 
     When the parties submit the following undelegations:
@@ -263,7 +263,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |   1000  |           |                                     |    
     | party1 |  node2   |   7578  |     a     | insufficient balance for delegation |     
 
-  Scenario: A party cannot delegate more than their staking account balance considering all active and pending undelegation 
+  Scenario: A party cannot delegate more than their staking account balance considering all active and pending undelegation (0059-STKG-007)
     Description: A party has pending delegations and undelegations and is trying to exceed their stake account balance delegation, 
     i.e. the balance of their pending delegation + requested delegation exceeds stake account balance
     
@@ -287,7 +287,8 @@ Feature: Staking & Delegation
     | party1 |  node2   |   1000  |           |                                     |    
     | party1 |  node2   |   8578  |     a     | insufficient balance for delegation |    
 
-  Scenario: A party can request delegate and undelegate from the same node at the same epoch such that the request can balance each other without affecting the actual delegate balance    Description: party requests to delegate to node1 at the end of the epoch and regrets it and undelegate the whole amount to delegate it to node2
+  Scenario: A party can request delegate and undelegate from the same node at the same epoch such that the request can balance each other without affecting the actual delegate balance (0059-STKG-0013)
+    Description: party requests to delegate to node1 at the end of the epoch and regrets it and undelegate the whole amount to delegate it to node2
   
     When the parties submit the following delegations:
     | party  | node id  |  amount | 
@@ -306,7 +307,7 @@ Feature: Staking & Delegation
     | party1 |  node1   | 0      | 
     | party1 |  node2   | 1000   | 
     
-    Scenario: A party has active delegations and submits an undelegate request followed by a delegation request that covers only part of the undelegation such that the undelegation still takes place
+  Scenario: A party has active delegations and submits an undelegate request followed by a delegation request that covers only part of the undelegation such that the undelegation still takes place (0059-STKG-013)
     Description: A party delegated tokens to node1 at previous epoch such that the delegations is now active and is requesting to undelegate some of the tokens at the end of the current epoch. Then regret some of it and submit a delegation request that undoes some of the undelegation but still some of it remains. 
 
     When the parties submit the following delegations:
@@ -327,7 +328,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   | 100    | 
 
-  Scenario: A party cannot undelegate more than the delegated balance 
+  Scenario: A party cannot undelegate more than the delegated balance (0059-STKG-unmapped)
     Description: A party trying to undeleagte from a node more than the amount that was delegated to it should fail 
 
     And the parties submit the following delegations:
@@ -348,7 +349,7 @@ Feature: Staking & Delegation
     | party1 |  node2    |    200   | end of epoch |           |                                          |    
     | party1 |  node3    |    300   | end of epoch |           |                                          |  
 
-  Scenario: A node can self delegate to itself and undelegate at the end of an epoch
+  Scenario: A node can self delegate to itself and undelegate at the end of an epoch (0059-STKG-unmapped)
     Description: A node with a balance in the staking account can delegate to itself
 
     When the parties submit the following delegations:
@@ -387,7 +388,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | node1  |  node1   |  6000  | 
       
-  Scenario: A party can undelegate all of their stake at the end of the epoch
+  Scenario: A party can undelegate all of their stake at the end of the epoch (0059-STKG-0014)
     Description: A with delegated stake and pending delegation can request to undelegate all. This will be translated to undelegating all the stake they have at the time and will be executed at the end of the epoch
 
     When the parties submit the following delegations:
@@ -423,7 +424,7 @@ Feature: Staking & Delegation
     | party1 |  node1   |   0    | 
     | party1 |  node2   |   123  |    
 
-  Scenario: A party can request to undelegate their stake or part of it right now
+  Scenario: A party can request to undelegate their stake or part of it right now (0059-STKG-015)
     Description: A party with delegated stake and/or pending delegation can request to undelegate all or part of it immediately as opposed to at the end of the epoch
 
     When the parties submit the following delegations:
@@ -466,7 +467,7 @@ Feature: Staking & Delegation
     | party1 |  node1   |   0    | 
     | party1 |  node2   |   123  |  
   
-  Scenario: A party withdraws from their staking account during an epoch - their stake is being undelegated automatically to match the difference
+  Scenario: A party withdraws from their staking account during an epoch - their stake is being undelegated automatically to match the difference (0059-STKG-011, 0059-STKG-012)
     Description: A party with delegated stake withdraws from their staking account during an epoch - at the end of the epoch when delegations are processed the party will be forced to undelegate the difference between the stake they have delegated and their staking account balance. 
 
     When the parties submit the following delegations:
@@ -494,7 +495,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |  500   |
 
-  Scenario: Undelegate now followed by withdraw - same behaviour as either underlegate now or withdraw
+  Scenario: Undelegate now followed by withdraw - same behaviour as either undelegate now or withdraw (0059-STKG-011, 0059-STKG-014, 0059-STKG-015)
 
     When the parties submit the following delegations:
     | party  | node id  | amount |
@@ -525,7 +526,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |  400   |     
 
-  Scenario: Withdrawal followed by undelegate now (same epoch) - same behaviour as either underlegate now or withdraw
+  Scenario: Withdrawal followed by undelegate now (same epoch) - same behaviour as either undelegate now or withdraw (0059-STKG-011, 0059-STKG-014, 0059-STKG-015)
 
     When the parties submit the following delegations:
     | party  | node id  | amount |
@@ -556,7 +557,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |    500 |    
 
-  Scenario: Withdrawal followed by undelegate now (next epoch) - results in additional undelegation
+  Scenario: Withdrawal followed by undelegate now (next epoch) - results in additional undelegation (0059-STKG-011, 0059-STKG-014, 0059-STKG-015)
 
     When the parties submit the following delegations:
     | party  | node id  | amount |
@@ -634,7 +635,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |    100 |    
 
-  Scenario: A validator gets past maximum stake by changing network parameter
+  Scenario: A validator gets past maximum stake by changing network parameter (0059-STKG-unmapped)
     Description: A party attempts to delegate token stake which exceed maximum stake for a validator
 
     When the parties submit the following delegations:
@@ -713,7 +714,7 @@ Feature: Staking & Delegation
       | party1 |  node2   | 2500   |       
       | party1 |  node3   | 4700   |
 
-  Scenario: A party undelegates now and then withdraws from their staking account during an epoch - their stake is being undelegated automatically to match the difference
+  Scenario: A party undelegates now and then withdraws from their staking account during an epoch - their stake is undelegated automatically to match the difference (0059-STKG-011)
     Description: A party undelegates now and then withdraws from their staking account during an epoch - then immediately delegations are processed the party will be forced to undelegate the difference between the stake they have delegated and their staking account balance. 
 
     When the parties submit the following delegations:
@@ -749,7 +750,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |  400   |     
 
-  Scenario: A party delegates and then withdraws from their staking account during the same epoch such that delegation is a successful
+  Scenario: A party delegates and then withdraws from their staking account during the same epoch such that delegation is a successful ( (0059-STKG-002, 0059-STKG-005, 0059-STKG-006, 0059-STKG-007, 0059-STKG-011)
     Description: A party delegates now and then withdraws from their staking account during the same epoch such that delegation is a successful
 
     When the parties submit the following delegations:
@@ -781,7 +782,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |  1000  |     
 
-  Scenario: A party delegates and then withdraws from their staking account during the same epoch such that delegation fails
+  Scenario: A party delegates and then withdraws from their staking account during the same epoch such that delegation fails (0059-STKG-002, 0059-STKG-005)
     Description: A party delegates now and then withdraws from their staking account during the same epoch such that delegation fails
 
     When the parties submit the following delegations:
@@ -813,7 +814,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |  500   |    
 
-  Scenario: A party withdraws from their staking account during an epoch - their stake is being undelegated automatically to match the difference
+  Scenario: A party withdraws from their staking account during an epoch - their stake is undelegated automatically to match the difference
     Description: A party with delegated stake withdraws from their staking account during an epoch - at the end of the epoch when delegations are processed the party will be forced to undelegate the difference between the stake they have delegated and their staking account balance. 
 
     When the parties submit the following delegations:

--- a/qa-scenarios/0061-delegation.feature
+++ b/qa-scenarios/0061-delegation.feature
@@ -137,7 +137,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |    0   |       
     | party1 |  node3   |    0   |        
 
-  Scenario: A party cannot delegate more than it has in staking account (0059-STKG-additional_tests)
+  Scenario: A party cannot delegate more than it has in staking account (0059-STKG-additional-tests)
     Description: A party attempts to delegate more than it has in its staking account to a validator
 
     When the parties submit the following delegations:
@@ -159,7 +159,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |    0   |       
     | party1 |  node3   |    0   |        
 
-  Scenario: A party cannot cumulatively delegate more than it has in staking account (0059-STKG-additional_tests)
+  Scenario: A party cannot cumulatively delegate more than it has in staking account (0059-STKG-additional-tests)
     
     When the parties submit the following delegations:
     | party  | node id  |   amount   | reference | error                               |
@@ -227,7 +227,7 @@ Feature: Staking & Delegation
     | party1 |  node2   | 20     |       
     | party1 |  node3   | 10     | 
 
-  Scenario: A party cannot delegate to an unknown node (0059-STKG-additional_tests)
+  Scenario: A party cannot delegate to an unknown node (0059-STKG-additional-tests)
     Description: A party should fail in trying to delegate to a non existing node
 
     When the parties submit the following delegations:
@@ -235,7 +235,7 @@ Feature: Staking & Delegation
     | party1 |  unknown1 |    100   |      a    | invalid node ID |
     | party1 |  unknonw2 |    200   |      b    | invalid node ID |    
 
-  Scenario: A party cannot undelegate from an unknown node (0059-STKG-additional_tests)
+  Scenario: A party cannot undelegate from an unknown node (0059-STKG-additional-tests)
     Description: A party should fail in trying to undelegate from a non existing node
 
     When the parties submit the following undelegations:
@@ -328,7 +328,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   | 100    | 
 
-  Scenario: A party cannot undelegate more than the delegated balance (0059-STKG-additional_tests)
+  Scenario: A party cannot undelegate more than the delegated balance (0059-STKG-additional-tests)
     Description: A party trying to undeleagte from a node more than the amount that was delegated to it should fail 
 
     And the parties submit the following delegations:
@@ -349,7 +349,7 @@ Feature: Staking & Delegation
     | party1 |  node2    |    200   | end of epoch |           |                                          |    
     | party1 |  node3    |    300   | end of epoch |           |                                          |  
 
-  Scenario: A node can self delegate to itself and undelegate at the end of an epoch (0059-STKG-additional_tests)
+  Scenario: A node can self delegate to itself and undelegate at the end of an epoch (0059-STKG-additional-tests)
     Description: A node with a balance in the staking account can delegate to itself
 
     When the parties submit the following delegations:
@@ -635,7 +635,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |    100 |    
 
-  Scenario: A validator gets past maximum stake by changing network parameter (0059-STKG-additional_tests)
+  Scenario: A validator gets past maximum stake by changing network parameter (0059-STKG-additional-tests)
     Description: A party attempts to delegate token stake which exceed maximum stake for a validator
 
     When the parties submit the following delegations:

--- a/qa-scenarios/0061-delegation.feature
+++ b/qa-scenarios/0061-delegation.feature
@@ -137,7 +137,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |    0   |       
     | party1 |  node3   |    0   |        
 
-  Scenario: A party cannot delegate more than it has in staking account (0059-STKG-unmapped)
+  Scenario: A party cannot delegate more than it has in staking account (0059-STKG-additional_tests)
     Description: A party attempts to delegate more than it has in its staking account to a validator
 
     When the parties submit the following delegations:
@@ -159,7 +159,7 @@ Feature: Staking & Delegation
     | party1 |  node2   |    0   |       
     | party1 |  node3   |    0   |        
 
-  Scenario: A party cannot cumulatively delegate more than it has in staking account (0059-STKG-unmapped)
+  Scenario: A party cannot cumulatively delegate more than it has in staking account (0059-STKG-additional_tests)
     
     When the parties submit the following delegations:
     | party  | node id  |   amount   | reference | error                               |
@@ -227,7 +227,7 @@ Feature: Staking & Delegation
     | party1 |  node2   | 20     |       
     | party1 |  node3   | 10     | 
 
-  Scenario: A party cannot delegate to an unknown node (0059-STKG-unmapped)
+  Scenario: A party cannot delegate to an unknown node (0059-STKG-additional_tests)
     Description: A party should fail in trying to delegate to a non existing node
 
     When the parties submit the following delegations:
@@ -235,7 +235,7 @@ Feature: Staking & Delegation
     | party1 |  unknown1 |    100   |      a    | invalid node ID |
     | party1 |  unknonw2 |    200   |      b    | invalid node ID |    
 
-  Scenario: A party cannot undelegate from an unknown node (0059-STKG-unmapped)
+  Scenario: A party cannot undelegate from an unknown node (0059-STKG-additional_tests)
     Description: A party should fail in trying to undelegate from a non existing node
 
     When the parties submit the following undelegations:
@@ -328,7 +328,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   | 100    | 
 
-  Scenario: A party cannot undelegate more than the delegated balance (0059-STKG-unmapped)
+  Scenario: A party cannot undelegate more than the delegated balance (0059-STKG-additional_tests)
     Description: A party trying to undeleagte from a node more than the amount that was delegated to it should fail 
 
     And the parties submit the following delegations:
@@ -349,7 +349,7 @@ Feature: Staking & Delegation
     | party1 |  node2    |    200   | end of epoch |           |                                          |    
     | party1 |  node3    |    300   | end of epoch |           |                                          |  
 
-  Scenario: A node can self delegate to itself and undelegate at the end of an epoch (0059-STKG-unmapped)
+  Scenario: A node can self delegate to itself and undelegate at the end of an epoch (0059-STKG-additional_tests)
     Description: A node with a balance in the staking account can delegate to itself
 
     When the parties submit the following delegations:
@@ -635,7 +635,7 @@ Feature: Staking & Delegation
     | party  | node id  | amount |
     | party1 |  node1   |    100 |    
 
-  Scenario: A validator gets past maximum stake by changing network parameter (0059-STKG-unmapped)
+  Scenario: A validator gets past maximum stake by changing network parameter (0059-STKG-additional_tests)
     Description: A party attempts to delegate token stake which exceed maximum stake for a validator
 
     When the parties submit the following delegations:


### PR DESCRIPTION
This is intended as a discussion for how we map the new Acceptance Criteria codes (#781, #799) on to feature files. It's not set in stone - let's decide if we like it, then expand the usage elsewhere.

# What's changed
1. If a `Scenario` in a `.feature` file appears to test _exactly one_ Acceptance Criteria, the AC code for that criteria is _appended to the scenario name_, in parenthesis
  ```Scenario: Example One``` becomes
  ```Scenario: Example One (0000-EXMP-0000)```
3.. If a `Scenario` in a `.feature` file appears to test _more than one_ Acceptance Criteria, the AC codes for that criteria is _appended to the scenario name_, in parenthesis, separated by commas
  ```Scenario: Example One``` becomes
  ```Scenario: Example One (0000-EXMP-0000, 0000-EXMP-0001)```
2. If a `Scenario` in a `.feature` file appears to test valuable things that are not explicitly Acceptance Criteria, the AC code `0000-EXMP-unmapped` is appended to the scenario name, in parenthesis
  ```Scenario: Example One``` becomes
  ```Scenario: Example One (0000-EXMP-additional-tests)```

Which is based on the following rules:
1. It is valid for a scenario to test things that aren't explicitly Acceptance Criteria in order to verify the system is operating correctly
2. Exhaustively mapping every scenario back in to a spec file is not a good use of time
3. It is valid for a scenario to touch multiple different Acceptance Criteria
4. Every Acceptance Criteria that has a code **should** have a test, but exactly where is not yet decided.
5. Every Scenario in a feature file **must** be updated to have one of the three things above - explicitly unmapped, 1 or more linked ACs
6. No scenario can have `0000-EXMP-unmapped` *and* AC codes. Unmapped should be removed when there are more than 0 ACs to link to.

# Notes
All of the above is open for change. Also, we may disagree on if a feature tests an AC. That's fine too! As long as we all agree what we want at the end of this PR. Also I think I missed some scenarios in this PR, so... I've already broken the rules.