### PR TITLE
Clarify ioc+fok orders

### DIFF
--- a/protocol/0014-ORDT-order_types.md
+++ b/protocol/0014-ORDT-order_types.md
@@ -56,9 +56,11 @@ Notes on scope of current version of this spec:
 
 | Pricing method | GTT | GTC | IOC | FOK | GFA | GFN |
 | -------------- |:---:|:---:|:---:|:---:|:---:|:---:|
-| Limit          | Y   | Y   | Y   | Y   | N   | Y   |
-| Pegged         | Y   | Y   | Y   | Y   | N   | Y   |
+| Limit          | Y   | Y   | Y*  | Y*  | N   | Y   |
+| Pegged         | Y   | Y   | Y*  | Y*  | N   | Y   |
 | Market         | N   | N   | Y   | Y   | N   | N   |
+
+\* IOC/FOK LIMIT/PEGGED orders never rest on the book, if they do not match immediately they are cancelled/stopped.
 
 
 ##### Auction


### PR DESCRIPTION
Small clarification to show that IOC/FOK orders can never rest on the book.

Closes #843 
