### PR TITLE
LP mechanics ACs

### DIFF
--- a/protocol/0013-ACCT-accounts.md
+++ b/protocol/0013-ACCT-accounts.md
@@ -93,19 +93,19 @@ When a trader no longer has collateral requirements for a  market (because they 
 
 If there is a positive balance in an account that is being deleted, that balance should be transferred to the account specified in the transfer request (which for margin accounts will typically be the insurance pool of the market).
 
+## Bond accounts
+Bond accounts are opened when a party opens a [Liquidity Provision order](./0038-OLIQ-liquidity_provision_order_type.md). The bond is held by the network to ensure that the Liquidity PRovider maintains enough collateral to cover their commitment. [0044-LIQM - LP Mechanics](./0044-LIQM-lp_mechanics.md) contains more detail on bond management. 
+
 ## Insurance pools
 
 Every market will have at least one insurance pool account that holds collateral that can be used to cover losses in case of unreasonable market events.
 
 **Creation:**
 
-When a market launches, an insurance pool account is created for that market for each settlement asset. This account is used by the protocol during the collection of [margin requirements](./0010-MARG-margin_orchestration.md) and the collection of [mark to market settlement](./0003-MTMK-mark_to_market_settlement.md). 
+When a [market launches](./0043-MKTL_market_livecycle.md), an insurance pool account is created for that market for each settlement asset. This account is used by the protocol during the collection of [margin requirements](./0010-MARG-margin_orchestration.md) and the collection of [mark to market settlement](./0003-MTMK-mark_to_market_settlement.md). 
 
 **Deletion:**
 
 When a market is finalised / closed remaining funds are distributed to the on chain treasury.  This occurs using ledger entries to preserve double entry accounting records within the collateral engine.
 
-# Pseudo-code / Examples
-
-# Test cases
 

--- a/protocol/0044-LIQM-lp_mechanics.md
+++ b/protocol/0044-LIQM-lp_mechanics.md
@@ -22,20 +22,9 @@ Any Vega participant can apply to become a liquidity provider (LP) on a market b
 1. ORDERS: a set of _liquidity buy orders_ and _liquidity sell orders_ ("buy shape" and "sell shape") to meet the liquidity provision obligation, see [MM orders spec](./0038-OLIQ-liquidity_provision_order_type.md).
 
 Accepted if all of the following are true:
-- [ ] The participant has sufficient collateral in their general account to meet the size of their nominated commitment amount, as specified in the transaction.
-- [ ] The participant has sufficient collateral in their general account to also meet the margins required to support the orders generated from their commitment.
-- [ ] The market is in a state that accepts new liquidity provision [market lifecycle spec](./0043-MKTL-market_lifecycle.md).
-- [ ] The nominated fee amount is greater than or equal to zero and less than the maximum level set by a network parameter (`maximum-liquidity-fee-factor-level`)
-- [ ] There is a set of valid buy/sell liquidity provision orders aka "buy shape" and "sell shape" (see [MM orders spec](./0038-OLIQ-liquidity_provision_order_type.md)).
-
-Invalid if any of the following are true:
-- [ ] Commitment amount is less than zero (zero is considered to be nominating to cease liquidity provision)
-- [ ] Nominated liquidity fee factor is less than zero
-- [ ] Acceptance criteria from [MM orders spec](./0038-OLIQ-liquidity_provision_order_type.md) is not met.
-
-Engineering notes:
-- check transaction, allocation margin could replace "check order, allocate margin"
-- some of these checks can happen pre consensus
+- The order is valid - see [0038-OLIQ-Liquidity provision order type spec](./0038-OLIQ-liquidity_provision_order_type.md) for full details
+- The participant has sufficient collateral in their general account to meet the size of their nominated commitment amount as well as the margin requirements 
+- The market is in a state that accepts new liquidity provision [market lifecycle spec](./0043-MKTL-market_lifecycle.md).
 
 General notes:
 - If market is in auction mode it won't be possible to check the margin requirements for orders generated from LP commitment. If on transition from auction the funds in margin and general accounts are insufficient to cover the margin requirements associated with those orders funds in bond account should be used to cover the shortfall (with no penalty applied as outlined in the [Penalties](#penalties) section). If even the entire bond account balance is insufficient to cover those margin requirement the liquidity commitment transaction should get cancelled.
@@ -58,7 +47,7 @@ When a commitment is made the liquidity commitment amount is assumed to be speci
 
 If the participant has sufficient collateral to cover their commitment and margins for the orders generated from their proposed commitment, the commitment amount (stake) is transferred from the participant's general account to their (maybe newly created) [liquidity provision bond account](./0013-ACCT-accounts.md#liquidity-provider-bond-accounts) (new account type, 1 per liquidity provider per market and asset where they are commitment liquidity, created as needed). For clarity, liquidity providers will have a separate [margin account](./0013-ACCT-accounts.md#trader-margin-accounts) and [bond account](./0013-ACCT-accounts.md#liquidity-provider-bond-accounts).
 
-- liquidity provider bond account:
+- Liquidity provider bond account:
     - [ ] Each active market has one bond account per liquidity provider, per settlement asset for that market.
     - [ ] When a liquidity provider transaction is approved, the size of their staked bond is immediately transferred from their general account to this bond account.
     - [ ] A liquidity provider can only prompt a transfer of funds to or from this account by submitting a valid transaction to create, increase, or decrease their commitment to the market, which must be validated and pass all checks (e.g. including those around minimum liquidity commitment required, when trying to reduce commitment). 
@@ -232,13 +221,8 @@ Valid values: any decimal number `>= 0` with a default value of `0.1`.
 - It should be possible to query all details of liquidity providers via an API
 
 
-## Further Acceptance Criteria
-
-- Becoming a liquidity provider:
-    - [ ] A network transaction exists that acts as an application for a participant to become a liquidity provider for a specified market.
-    - [ ] The application is accepted by the network if both of following are true:
-       - [ ] The participant has sufficient collateral in their general account to meet the size of staked bond, specified in their transaction.
-       - [ ] The market is active
-    - [ ] Any Vega participant can apply to provide liquidity on any market.
-    	- When a user has submitted a [Liquidity Provision order](./0038-OLIQ-liquidity_provision_order_type.md), a Bond account is created for that user and for that market
-	- Collateral required to maintain the Liquidity Provision Order will be held in the Bond account.
+## Acceptance Criteria
+- Through the API, I can list all active liquidity providers for a market (<a name="0044-LIQM-001" href="#0044-LIQM-001">0044-LIQM-001</a>)
+- If a liquidity
+- If a liquidity provider does not have enough in their general account to top up their margin & bond accounts:
+    - If there is sufficient collateral to top up the margin account, the margin account is topped up and the LP commitment is set to 0 

--- a/protocol/0044-LIQM-lp_mechanics.md
+++ b/protocol/0044-LIQM-lp_mechanics.md
@@ -223,6 +223,4 @@ Valid values: any decimal number `>= 0` with a default value of `0.1`.
 
 ## Acceptance Criteria
 - Through the API, I can list all active liquidity providers for a market (<a name="0044-LIQM-001" href="#0044-LIQM-001">0044-LIQM-001</a>)
-- If a liquidity
-- If a liquidity provider does not have enough in their general account to top up their margin & bond accounts:
-    - If there is sufficient collateral to top up the margin account, the margin account is topped up and the LP commitment is set to 0 
+- The [bond slashing](./qa-scenarios/liquidity-provision-bond-account.feature) works as the feature test claims. (<a name="0044-LIQM-001" href="#0044-LIQM-002">0044-LIQM-002</a>).

--- a/protocol/0044-LIQM-lp_mechanics.md
+++ b/protocol/0044-LIQM-lp_mechanics.md
@@ -223,4 +223,4 @@ Valid values: any decimal number `>= 0` with a default value of `0.1`.
 
 ## Acceptance Criteria
 - Through the API, I can list all active liquidity providers for a market (<a name="0044-LIQM-001" href="#0044-LIQM-001">0044-LIQM-001</a>)
-- The [bond slashing](./qa-scenarios/liquidity-provision-bond-account.feature) works as the feature test claims. (<a name="0044-LIQM-001" href="#0044-LIQM-002">0044-LIQM-002</a>).
+- The [bond slashing](./qa-scenarios/liquidity-provision-bond-account.feature) works as the feature test claims. (<a name="0044-LIQM-002" href="#0044-LIQM-002">0044-LIQM-002</a>).


### PR DESCRIPTION
Pushing so I can hand over to @davidsiska-vega, as I can't parse enough ACs out about how bond account / margin account orchestration happens in precise enough detail to populate adequate ACs.

What I want to add is some labelled acceptance criteria that would let us test that the way penalties happen for bond account providers is correct.
- If an LP has enough in their general account to top up a margin account, but not enough to top up their bond account, then … ? I think the LP commitment is reduced
- A scenario that correctly tests the slashing amount is correctly calculated using the network parameters
- A scenario that tests the transfers that happen between bond & margin accounts is correct
- A scenario that tests that slashed bonds are transferred to the insurance pool

Closes #823 