### PR TITLE
Removed negative offset values and made it clear how they work now.

### DIFF
--- a/protocol/0037-OPEG-pegged_orders.md
+++ b/protocol/0037-OPEG-pegged_orders.md
@@ -31,7 +31,7 @@ Pegged orders are limit orders where the price is specified of the form `REFEREN
 
 **Reference Price:** This is the price against which the final order priced is calculated. Possible options are best bid/ask and mid price.
 
-**Offset:** This is a value added to the reference price. It can be negative and must be a multiple of the tick size.
+**Offset:** This is a value added to the reference price. It must be positive and must be a multiple of the tick size.
 
 When a party submits a new pegged order, only a LIMIT order is accepted. The party also specifies the reference price to which the order will be priced along with an offset to apply to this price. The reference price is looked up from the live market and the final price is calculated and used to insert the new order. The order is placed on the book at the back of the calculated price level.
 

--- a/protocol/0038-OLIQ-liquidity_provision_order_type.md
+++ b/protocol/0038-OLIQ-liquidity_provision_order_type.md
@@ -25,19 +25,27 @@ Each entry must specify:
 
 1. **Liquidity proportion:** the relative proportion of the commitment to be allocated at a price level. Note, the network will normalise the liquidity proportions of the refined order set (see below). This must be a strictly positive number.
 
-2. A **price peg:** , as per normal [pegged orders](../protocol/0037-OPEG-pegged_orders.md), a price level specified by a reference point (e.g mid, best bid, best offer) and an amount of units away. 
+2. A **price peg:** , as per normal [pegged orders](../protocol/0037-OPEG-pegged_orders.md), a price level specified by a reference point (e.g mid, best bid, best offer) and an amount of units away. The amount is always positive and is subtracted for buy orders and added for sell orders to the reference price.
 
 ```
 # Example 1:
 Buy-shape: {
-  buy-entry-1: [liquidity-proportion-1, [price-peg-reference-1, number-of-units-from-reference-1]],
-  buy-entry-2: [liquidity-proportion-2, [price-peg-reference-2, number-of-units-from-reference-2]],
+  buy-entry-1: [buy-liquidity-proportion-1, [buy-price-peg-reference-1, buy-number-of-units-from-reference-1]],
+  buy-entry-2: [buy-liquidity-proportion-2, [buy-price-peg-reference-2, buy-number-of-units-from-reference-2]],
+}
+Sell-shape: {
+  sell-entry-1: [sell-liquidity-proportion-1, [sell-price-peg-reference-1, sell-number-of-units-from-reference-1]],
+  sell-entry-2: [sell-liquidity-proportion-2, [sell-price-peg-reference-2, sell-number-of-units-from-reference-2]],
 }
 
 # Example 1 with values
 Buy-shape: {
-  buy-entry-1: [2, [best-bid, -10]],
-  buy-entry-2: [13, [best-bid, -11]],
+  buy-entry-1: [2, [best-bid, 10]],
+  buy-entry-2: [13, [best-bid, 11]],
+}
+Sell-shape: {
+  sell-entry-1: [5, [best-ask, 8]],
+  sell-entry-2: [5, [best-ask, 9]],
 }
 
 ```
@@ -69,10 +77,12 @@ Calculate the `liquidity-normalised-proportion` for all entries, where:
 `liquidity-normalised-proportion = liquidity-proportion-for-entry / sum-all-buy/sell-entries(liquidity-proportion-for-order)`
 
 ```
-Example 1 (from above) where refined-buy-order-list = [buy-entry-1, buy-entry-2]:
+Example 1 (from above) where refined-buy-order-list = [buy-entry-1, buy-entry-2, sell-entry-1, sell-entry-2]:
 
-liquidity-normalised-proportion-order-1 = 2 / (2 + 13) = 0.133333
-liquidity-normalised-proportion-order-2 = 13 / (2 + 13) = 0.866666
+liquidity-normalised-proportion-buy-order-1 = 2 / (2 + 13 + 5 + 5) = 0.08
+liquidity-normalised-proportion-buy-order-2 = 13 / (2 + 13 + 5 + 5) = 0.52
+liquidity-normalised-proportion-sell-order-1 = 5 / (2 + 13 + 5 + 5) = 0.2
+liquidity-normalised-proportion-sell-order-2 = 5 / (2 + 13 + 5 + 5) = 0.2
 
 ```
 The sum of all normalised proportions must = 1 for all refined buy / sell order list.
@@ -102,7 +112,7 @@ Example:
 best-static-bid-on-order-book = 103
 
 shape-entry = {
-  peg: {reference: 'best-bid', units-from-ref: -2}, 
+  peg: {reference: 'best-bid', units-from-ref: 2}, 
   liquidity-normalised-proportion-order: 0.32
 }
 


### PR DESCRIPTION
Updated the spec to clarify that pegged order offsets are always positive and that we must supply and buy an sell shape when submitting a LP submission.

Close #926 
