### PR TITLE
Add null blockchain acceptance criteria

### DIFF
--- a/non-protocol-specs/0008-NP-NULB-null_blockchain_vega.md
+++ b/non-protocol-specs/0008-NP-NULB-null_blockchain_vega.md
@@ -42,3 +42,9 @@ An extra API is added to allow the user to control the time and block start/end 
 - Time can only move forward
   - I submit `{ forward: "-10s" }` to the time fast forward endpoint. Time does not move and I receive an error. (<a name="0008-NP-NULB-001" href="#0008-NP-NULB-001">0008-NP-NULB-001</a>)
   - I submit `{ forward: "<a date in the past>" }` to the time fast forward endpoint. Time does not move and I receive an error. (<a name="0008-NP-NULB-002" href="#0008-NP-NULB-002">0008-NP-NULB-002</a>)
+- The null blockchain block time does not control the automatic creation of blocks
+  - With the block time set to `1 second`, if at block height 1 I perform no actions for 5 seconds, the block height will still be 1 (<a name="0008-NP-NULB-003" href="#0008-NP-NULB-003">0008-NP-NULB-003</a>)
+  - With the transactions-per-block configuration set to `2`
+   - If at block height 1 I submit 3 transactions, the block height will have increased to 2 (<a name="0008-NP-NULB-004" href="#0008-NP-NULB-004">0008-NP-NULB-004</a>)
+   - If at block height 1 I submit 1 transaction, the block height will still be 1 ( (<a name="0008-NP-NULB-005" href="#0008-NP-NULB-005">0008-NP-NULB-005</a>))
+  - If at block height 1 I move time forward by 1s, the block height will have increased to 2 ( (<a name="0008-NP-NULB-006" href="#0008-NP-NULB-006">0008-NP-NULB-006</a>))

--- a/non-protocol-specs/0008-NP-NULB-null_blockchain_vega.md
+++ b/non-protocol-specs/0008-NP-NULB-null_blockchain_vega.md
@@ -34,11 +34,11 @@ Event bus data can be recorded either in the test app via a subscription to the 
 Null blockchain Vega must support all the APIs that Vega core supports with all the standard language bindings plus the additional ones outlined above. 
 An extra API is added to allow the user to control the time and block start/end times without changing the standard API endpoints.
 
-## Acceptance criteria
+# Acceptance criteria
 
 - It is possible to take a functioning sample API script, change the config so it points at a null blockchain vega node, add some time passage commands and run it.
-
 - There is golang example which creates three parties, gives them assets, one party proposes a market and acts as LP, the remaining two parties trade, placing one trade per day for "365 days".  The LP party submits a trading terminated transaction after "365 days" and a subsequent settlement price transaction and the market settles. All of this executes within 0.1 second on a Raspberry PI.
+
 - Time can only move forward
   - I submit `{ forward: "-10s" }` to the time fast forward endpoint. Time does not move and I receive an error. (<a name="0008-NP-NULB-001" href="#0008-NP-NULB-001">0008-NP-NULB-001</a>)
   - I submit `{ forward: "<a date in the past>" }` to the time fast forward endpoint. Time does not move and I receive an error. (<a name="0008-NP-NULB-002" href="#0008-NP-NULB-002">0008-NP-NULB-002</a>)
@@ -48,3 +48,5 @@ An extra API is added to allow the user to control the time and block start/end 
    - If at block height 1 I submit 3 transactions, the block height will have increased to 2 (<a name="0008-NP-NULB-004" href="#0008-NP-NULB-004">0008-NP-NULB-004</a>)
    - If at block height 1 I submit 1 transaction, the block height will still be 1 ( (<a name="0008-NP-NULB-005" href="#0008-NP-NULB-005">0008-NP-NULB-005</a>))
   - If at block height 1 I move time forward by 1s, the block height will have increased to 2 ( (<a name="0008-NP-NULB-006" href="#0008-NP-NULB-006">0008-NP-NULB-006</a>))
+
+

--- a/non-protocol-specs/0008-NP-NULB-null_blockchain_vega.md
+++ b/non-protocol-specs/0008-NP-NULB-null_blockchain_vega.md
@@ -36,9 +36,6 @@ An extra API is added to allow the user to control the time and block start/end 
 
 # Acceptance criteria
 
-- It is possible to take a functioning sample API script, change the config so it points at a null blockchain vega node, add some time passage commands and run it.
-- There is golang example which creates three parties, gives them assets, one party proposes a market and acts as LP, the remaining two parties trade, placing one trade per day for "365 days".  The LP party submits a trading terminated transaction after "365 days" and a subsequent settlement price transaction and the market settles. All of this executes within 0.1 second on a Raspberry PI.
-
 - Time can only move forward
   - I submit `{ forward: "-10s" }` to the time fast forward endpoint. Time does not move and I receive an error. (<a name="0008-NP-NULB-001" href="#0008-NP-NULB-001">0008-NP-NULB-001</a>)
   - I submit `{ forward: "<a date in the past>" }` to the time fast forward endpoint. Time does not move and I receive an error. (<a name="0008-NP-NULB-002" href="#0008-NP-NULB-002">0008-NP-NULB-002</a>)
@@ -46,7 +43,8 @@ An extra API is added to allow the user to control the time and block start/end 
   - With the block time set to `1 second`, if at block height 1 I perform no actions for 5 seconds, the block height will still be 1 (<a name="0008-NP-NULB-003" href="#0008-NP-NULB-003">0008-NP-NULB-003</a>)
   - With the transactions-per-block configuration set to `2`
    - If at block height 1 I submit 3 transactions, the block height will have increased to 2 (<a name="0008-NP-NULB-004" href="#0008-NP-NULB-004">0008-NP-NULB-004</a>)
-   - If at block height 1 I submit 1 transaction, the block height will still be 1 ( (<a name="0008-NP-NULB-005" href="#0008-NP-NULB-005">0008-NP-NULB-005</a>))
-  - If at block height 1 I move time forward by 1s, the block height will have increased to 2 ( (<a name="0008-NP-NULB-006" href="#0008-NP-NULB-006">0008-NP-NULB-006</a>))
+   - If at block height 1 I submit 1 transaction, the block height will still be 1 (<a name="0008-NP-NULB-005" href="#0008-NP-NULB-005">0008-NP-NULB-005</a>)
+  - If at block height 1 I move time forward by 1s, the block height will have increased to 2 (<a name="0008-NP-NULB-006" href="#0008-NP-NULB-006">0008-NP-NULB-006</a>)
+- There is golang example which creates three parties, gives them assets, one party proposes a market and acts as LP, the remaining two parties trade, placing one trade per day for "365 days".  The LP party submits a trading terminated transaction after "365 days" and a subsequent settlement price transaction and the market settles. (<a name="0008-NP-NULB-007" href="#0008-NP-NULB-007">0008-NP-NULB-007</a>) 
 
 

--- a/non-protocol-specs/0008-NP-NULB-null_blockchain_vega.md
+++ b/non-protocol-specs/0008-NP-NULB-null_blockchain_vega.md
@@ -39,3 +39,6 @@ An extra API is added to allow the user to control the time and block start/end 
 - It is possible to take a functioning sample API script, change the config so it points at a null blockchain vega node, add some time passage commands and run it.
 
 - There is golang example which creates three parties, gives them assets, one party proposes a market and acts as LP, the remaining two parties trade, placing one trade per day for "365 days".  The LP party submits a trading terminated transaction after "365 days" and a subsequent settlement price transaction and the market settles. All of this executes within 0.1 second on a Raspberry PI.
+- Time can only move forward
+  - I submit `{ forward: "-10s" }` to the time fast forward endpoint. Time does not move and I receive an error. (<a name="0008-NP-NULB-001" href="#0008-NP-NULB-001">0008-NP-NULB-001</a>)
+  - I submit `{ forward: "<a date in the past>" }` to the time fast forward endpoint. Time does not move and I receive an error. (<a name="0008-NP-NULB-002" href="#0008-NP-NULB-002">0008-NP-NULB-002</a>)


### PR DESCRIPTION
I’ve added some fairly uncontroversial acceptance criteria to test that what’s delivered matches. I think the unit tests that are already in the folder cover a lot of these already, so it’s not so much a prompt for a whole new set of tests, as it is a third party verifying that they understand the spec and the implementation correctly.

I left the two old ‘criteria’ in there, but mostly ignored them. They’re sort of … aspirations rather than criteria, but hey - I thought they were still useful

ACs before: 0
ACs after: 6
Remaining files without ACs after merge: 13