### PR TITLE
Add ACs to product spec

### DIFF
--- a/protocol/0016-PFUT-product_builtin_future.md
+++ b/protocol/0016-PFUT-product_builtin_future.md
@@ -54,7 +54,7 @@ cash_settled_future.settlement_data(event) {
 		return
 	}
 
-	final_cashflow = cash_settled_future.value(event.data) - cash_settled_future.value(market.mark_price)) 
+	final_cashflow = cash_settled_future.value(event.data) - cash_settled_future.value(market.mark_price)
 	settle(cash_settled_future.settlement_asset, final_cashflow)
 	setMarkPrice(event.data)
 	setMarketStatus(SETTLED)
@@ -69,7 +69,7 @@ cash_settled_future.settlement_data(event) {
 3. Create a Cash Settled Future with the settlement data provided by an external data source (<a name="0016-PFUT-003" href="#0016-PFUT-003">0016-PFUT-003</a>)
 4. Create a Cash Settled Future for any settlement asset that's configured in Vega
   1. Either data source can be changed via governance (<a name="0016-PFUT-004" href="#0016-PFUT-004">0016-PFUT-004</a>)
-  2. It is not possible to change settlement asset via governance (<a name="0016-PFUT-005" href="#0016-PFUT-005">0016-PFUT-005</a>)
+  2. It is not possible to change settlement asset via governance (<a href="./0051-PROD-product.md#0051-PROD-005">0051-PFUT-005</a>)
   3. Mark to market settlement works correctly (<a name="0016-PFUT-006" href="#0016-PFUT-006">0016-PFUT-006</a>)
   4. Settlement at expiry works correctly (<a name="0016-PFUT-007" href="#0016-PFUT-007">0016-PFUT-007</a>)
 1. A market that receives settlement data before trading termination is suspended (<a name="0016-PFUT-008" href="#0016-PFUT-008">0016-PFUT-008</a>)

--- a/protocol/0051-PROD-product.md
+++ b/protocol/0051-PROD-product.md
@@ -126,11 +126,9 @@ APIS should be available to:
 
 1. Settlement assets
   1. A product of any type cannot be created without specifying at least one settlement asset (<a name="0051-PROD-001" href="#0051-PROD-001">0051-PROD-001</a>)
-  2. Some product types can have more than one settlement asset (<a name="0051-PROD-002" href="#0051-PROD-002">0051-PROD-002</a>)
-  3. The settlement asset or assets must exist at the time when the product is created (<a name="0051-PROD-003" href="#0051-PROD-003">0051-PROD-003</a>)
+  2. The settlement asset or assets must exist at the time when the product is created (<a name="0051-PROD-002" href="#0051-PROD-002">0051-PROD-002</a>)
 2. Product updates via governance
-  1. Any product parameter that is not a settlement can be updated via a governance market proposal (<a name="0051-PROD-004" href="#0051-PROD-004">0051-PROD-004</a>)
-  2. The settlement asset / settlement assets cannot be changed on a product via governance  (<a name="0051-PROD-005" href="#0051-PROD-005">0051-PROD-005</a>)
+  1. The settlement asset / settlement assets cannot be changed on a product via governance  (<a name="0051-PROD-003" href="#0051-PROD-003">0051-PROD-003</a>)
   
 # See also
 - [Product: Built In Futures](./016-PFUT-product_builtin_future.md) 

--- a/protocol/0051-PROD-product.md
+++ b/protocol/0051-PROD-product.md
@@ -73,7 +73,7 @@ callOption.value(quote) {
 	return BlackScholesCallPrice(underlying, strike, timeToMaturity, rfRate, bsVol)
 }
 ```
-## Quote-to-value function 
+## Quote-to-value function
 
 See [Fees spec](./0029-FEES-fees.md) for context. Fees are calculated based on `trade_value_for_fee_purposes`. Any product *may* provide `product.valueForFeePurposes(quote)` function which returns the value of the product for size of `1` which will be used in calculating fees: 
 For many products this will simply be
@@ -124,4 +124,14 @@ APIS should be available to:
 
 # Acceptance criteria
 
-1. 
+1. Settlement assets
+  1. A product of any type cannot be created without specifying at least one settlement asset (<a name="0051-PROD-001" href="#0051-PROD-001">0051-PROD-001</a>)
+  2. Some product types can have more than one settlement asset (<a name="0051-PROD-002" href="#0051-PROD-002">0051-PROD-002</a>)
+  3. The settlement asset or assets must exist at the time when the product is created (<a name="0051-PROD-003" href="#0051-PROD-003">0051-PROD-003</a>)
+2. Product updates via governance
+  1. Any product parameter that is not a settlement can be updated via a governance market proposal (<a name="0051-PROD-004" href="#0051-PROD-004">0051-PROD-004</a>)
+  2. The settlement asset / settlement assets cannot be changed on a product via governance  (<a name="0051-PROD-005" href="#0051-PROD-005">0051-PROD-005</a>)
+  
+# See also
+- [Product: Built In Futures](./016-PFUT-product_builtin_future.md) 
+- [Product: Cash settled Perpetual Future](./0053-PERP-product_builtin_perpetual_future.md)


### PR DESCRIPTION
The product spec is sort of 'high level' - the futures spec is a concrete implementation
of A future, and that spec already has tests. So these are relatively basic. There is one
tests here that explicitly duplicates a Futures one, so I made that reference this.

- Add ACs to 0051-PROD
- Update 0016-PFUT to reference an AC in 0051-PROD

Closes #903
