### PR TITLE
Add staking account details to 0013

### DIFF
--- a/protocol/0013-ACCT-accounts.md
+++ b/protocol/0013-ACCT-accounts.md
@@ -1,44 +1,5 @@
 Feature name: accounts
 
-# Acceptance Criteria
-
-## All accounts
-
-- [ ] Double entry accounting is maintained at all points. (<a name="0013-ACCT-001" href="#0013-ACCT-001">0013-ACCT-001</a>)
-- [ ] Only transfer requests move money between accounts. (<a name="0013-ACCT-002" href="#0013-ACCT-002">0013-ACCT-002</a>)
-
-## Party asset accounts
-- [ ] Every party that deposits an asset on Vega will have an asset account created for that asset. (<a name="0013-ACCT-003" href="#0013-ACCT-003">0013-ACCT-003</a>)
-  -  [ ] Only one general asset account exists per party per asset. (<a name="0013-ACCT-004" href="#0013-ACCT-004">0013-ACCT-004</a>)
-  -  [ ] When a party deposits collateral onto Vega, the asset account will increase in balance by the same amount. (<a name="0013-ACCT-005" href="#0013-ACCT-005">0013-ACCT-005</a>)
-  -  [ ] When a party withdraws collateral onto Vega, the asset account for that asset will decrease in balance by the same amount. (<a name="0013-ACCT-006" href="#0013-ACCT-006">0013-ACCT-006</a>) 
-
-## Party margin accounts
-- [ ] Every party that submits an order on a market will have a margin account for that market created. (<a name="0013-ACCT-007" href="#0013-ACCT-007">0013-ACCT-007</a>)
-- [ ] Each party should only have one margin account per market. (<a name="0013-ACCT-008" href="#0013-ACCT-008">0013-ACCT-008</a>)
-- [ ] Cannot have a non-zero balance on a margin account where there's no position / position size = 0 and no active orders. (<a name="0013-ACCT-009" href="#0013-ACCT-009">0013-ACCT-009</a>)
-- [ ] Cannot transfer into or out of a margin account where there's no position / position size = 0 and no active orders. (<a name="0013-ACCT-010" href="#0013-ACCT-010">0013-ACCT-010</a>)
-- [ ] [Fees earned from liquidity provision](./0044-LIQM-lp_mechanics.md#fees) are paid in to this account. (<a name="0013-ACCT-011" href="#0013-ACCT-011">0013-ACCT-011</a>)
-
-## Party staking accounts
-- [ ] Every party that deposits staked asset on Vega will have a stake account created for that asset. (<a name="0013-ACCT-012" href="#0013-ACCT-012">0013-ACCT-012</a>)
-  - [ ] Only one staked asset account exists per party per asset. (<a name="0013-ACCT-013" href="#0013-ACCT-013">0013-ACCT-013</a>)
-  - [ ] The balance can only be delegated to Validators (<a name="0013-ACCT-014" href="#0013-ACCT-014">0013-ACCT-014</a>)
-  - [ ] The balance cannot be traded, or used as margin, or transferred, or withdrawn (<a name="0013-ACCT-015" href="#0013-ACCT-015">0013-ACCT-015</a>)
-  - [ ] Delegated stake remains in the trader's staking account (<a name="0013-ACCT-016" href="#0013-ACCT-016">0013-ACCT-016</a>)
-
-One key difference with staking accounts is that the collateral is not held in an asset bridge, but in the [staking bridge](../non-protocol-specs/0006-NP-STAK-erc20_governance_token_staking.md). The balance is changed by events on Ethereum, rather than actions taken on the Vega chain.
-
-## Liquidity Provider bond accounts
-- [ ] A bond account holds collateral to maintain collateral for [Liquidity Providers](./0044-LIQM-lp_mechanics.md). (<a name="0013-ACCT-017" href="#0013-ACCT-017">0013-ACCT-017</a>)
-- [ ] Each party that has placed a [Liquidity Provision order](./0038-OLIQ-liquidity_provision_order_type.md) will have one bond account per market they have provided liquidity to (<a name="0013-ACCT-018" href="#0013-ACCT-018">0013-ACCT-018</a>)
-- [ ] [Fees earned from liquidity provision](./0044-LIQM-lp_mechanics.md#fees) are *not* paid in to this bond account - [they are paid in to the _margin_ account for this trader](./0042-LIQF-setting_fees_and_rewarding_lps.md#distributing-fees) (<a name="0013-ACCT-019" href="#0013-ACCT-019">0013-ACCT-019</a>)
-
-## Insurance pool accounts
-- [ ] When a market opens for trading, there is an insurance account that is able to be used by that market for every settlement asset of that market. (<a name="0013-ACCT-020" href="#0013-ACCT-020">0013-ACCT-020</a>)
-- [ ] Only transfer requests move money in or out of the insurance account. (<a name="0013-ACCT-021" href="#0013-ACCT-021">0013-ACCT-021</a>)
-- [ ] When all markets of a risk universe expire and/or are closed, the insurance pool account has its outstanding funds transferred to the [network treasury](./0055-TREA-on_chain_treasury.md) account for the appropriate asset (if it doesn't exist create it).  (<a name="0013-ACCT-022" href="#0013-ACCT-022">0013-ACCT-022</a>)
-
 
 # Summary
 
@@ -52,9 +13,7 @@ Various actions that occur in the protocol will prompt the creation and/or delet
 All accounts must:
 
 - have an initial value of zero for whichever asset it maintains
-
 - only change balance as a response to a valid transfer request that adheres to double entry accounting standards.
-
 - only be created and deleted by transfer requests. Deletion account transfer requests must specify which account should receive any outstanding funds in the account that's being deleted.
 
 ## Accounts for assets
@@ -108,4 +67,48 @@ When a [market launches](./0043-MKTL_market_livecycle.md), an insurance pool acc
 
 When a market is finalised / closed remaining funds are distributed to the on chain treasury.  This occurs using ledger entries to preserve double entry accounting records within the collateral engine.
 
+# Staking accounts
+In Vega governance is controlled by a [governance token](./0029-GOVE-governance.md#governance-asset) which is [nominated and staked](./0059-STKG-simple_staking_and_governance.md), and is held in a smart contract on Ethereum. As the assets are held off-chain, a party's staking balance is treated differently to the account types above.
 
+- Like [margin accounts](#margin-accounts), a party cannot transfer or place orders with the balance in staking accounts
+
+Note that it *is* possible to have markets in the governance asset, in which case all of the accounts detailed above will still apply. Staking accounts only relate to the balance of the governance asset that has been staked.
+
+# Acceptance Criteria
+## All ordinary accounts
+
+- [ ] Double entry accounting is maintained at all points. (<a name="0013-ACCT-001" href="#0013-ACCT-001">0013-ACCT-001</a>)
+- [ ] Only transfer requests move money between accounts. (<a name="0013-ACCT-002" href="#0013-ACCT-002">0013-ACCT-002</a>)
+
+### Party asset accounts
+- [ ] Every party that deposits an asset on Vega will have an asset account created for that asset. (<a name="0013-ACCT-003" href="#0013-ACCT-003">0013-ACCT-003</a>)
+  -  [ ] Only one general asset account exists per party per asset. (<a name="0013-ACCT-004" href="#0013-ACCT-004">0013-ACCT-004</a>)
+  -  [ ] When a party deposits collateral onto Vega, the asset account will increase in balance by the same amount. (<a name="0013-ACCT-005" href="#0013-ACCT-005">0013-ACCT-005</a>)
+  -  [ ] When a party withdraws collateral onto Vega, the asset account for that asset will decrease in balance by the same amount. (<a name="0013-ACCT-006" href="#0013-ACCT-006">0013-ACCT-006</a>) 
+
+### Party margin accounts
+- [ ] Every party that submits an order on a market will have a margin account for that market created. (<a name="0013-ACCT-007" href="#0013-ACCT-007">0013-ACCT-007</a>)
+- [ ] Each party should only have one margin account per market. (<a name="0013-ACCT-008" href="#0013-ACCT-008">0013-ACCT-008</a>)
+- [ ] Cannot have a non-zero balance on a margin account where there's no position / position size = 0 and no active orders. (<a name="0013-ACCT-009" href="#0013-ACCT-009">0013-ACCT-009</a>)
+- [ ] Cannot transfer into or out of a margin account where there's no position / position size = 0 and no active orders. (<a name="0013-ACCT-010" href="#0013-ACCT-010">0013-ACCT-010</a>)
+- [ ] [Fees earned from liquidity provision](./0044-LIQM-lp_mechanics.md#fees) are paid in to this account. (<a name="0013-ACCT-011" href="#0013-ACCT-011">0013-ACCT-011</a>)
+
+### Liquidity Provider bond accounts
+- [ ] A bond account holds collateral to maintain collateral for [Liquidity Providers](./0044-LIQM-lp_mechanics.md). (<a name="0013-ACCT-017" href="#0013-ACCT-017">0013-ACCT-017</a>)
+- [ ] Each party that has placed a [Liquidity Provision order](./0038-OLIQ-liquidity_provision_order_type.md) will have one bond account per market they have provided liquidity to (<a name="0013-ACCT-018" href="#0013-ACCT-018">0013-ACCT-018</a>)
+- [ ] [Fees earned from liquidity provision](./0044-LIQM-lp_mechanics.md#fees) are *not* paid in to this bond account - [they are paid in to the _margin_ account for this trader](./0042-LIQF-setting_fees_and_rewarding_lps.md#distributing-fees) (<a name="0013-ACCT-019" href="#0013-ACCT-019">0013-ACCT-019</a>)
+
+### Insurance pool accounts
+- [ ] When a market opens for trading, there is an insurance account that is able to be used by that market for every settlement asset of that market. (<a name="0013-ACCT-020" href="#0013-ACCT-020">0013-ACCT-020</a>)
+- [ ] Only transfer requests move money in or out of the insurance account. (<a name="0013-ACCT-021" href="#0013-ACCT-021">0013-ACCT-021</a>)
+- [ ] When all markets of a risk universe expire and/or are closed, the insurance pool account has its outstanding funds transferred to the [network treasury](./0055-TREA-on_chain_treasury.md) account for the appropriate asset (if it doesn't exist create it).  (<a name="0013-ACCT-022" href="#0013-ACCT-022">0013-ACCT-022</a>)
+
+## Special case: Staking accounts
+One key difference with staking accounts is that the collateral is not held in an asset bridge, but in the [staking bridge](../non-protocol-specs/0006-NP-STAK-erc20_governance_token_staking.md). The balance is changed by events on Ethereum, rather than actions taken on the Vega chain. For more information on staking and stake delegation see [Simple staking and delegation](./0050-STKG-simple_staking_and_delegating.md).
+
+## Party staking accounts
+- [ ] Every party that deposits staked asset on Vega will have a stake account created for that asset. (<a name="0013-ACCT-012" href="#0013-ACCT-012">0013-ACCT-012</a>)
+  - [ ] Only one staked asset account exists per party per asset. (<a name="0013-ACCT-013" href="#0013-ACCT-013">0013-ACCT-013</a>)
+  - [ ] The balance can only be delegated to Validators (<a name="0013-ACCT-014" href="#0013-ACCT-014">0013-ACCT-014</a>)
+  - [ ] The balance cannot be traded, or used as margin, or transferred, or withdrawn (<a name="0013-ACCT-015" href="#0013-ACCT-015">0013-ACCT-015</a>)
+  - [ ] Delegated stake remains in the trader's staking account (<a name="0013-ACCT-016" href="#0013-ACCT-016">0013-ACCT-016</a>)

--- a/protocol/0059-STKG-simple_staking_and_delegating.md
+++ b/protocol/0059-STKG-simple_staking_and_delegating.md
@@ -56,7 +56,7 @@ Any locked and undelegated stake can be delegated at any time by putting a
 delegation-message on the chain. However, the delegation only becomes valid 
 towards the next epoch, though it can be undone through undelegate.
 
-Once Vega is aware of locked tokens, the users will have an account with the balance reflecting how many tokens were locked. At this point, the user can submit a transaction to stake (delegate) their tokens. The amount they stake must be `<= balance`, naturally. 
+Once Vega is aware of locked tokens, the users will have an [account](./0013-ACCT-accounts.md#staking-accounts) with the balance reflecting how many tokens were locked. At this point, the user can submit a transaction to stake (delegate) their tokens. The amount they stake must be `<= balance`, naturally. 
 
 ```proto
 message Delegate {
@@ -175,7 +175,7 @@ See the [network paramters spec](./0054-NETP-network_parameters.md#current-netwo
   - Have enough tokens to satisfy the network parameter: "Minimum delegateable stake" (<a name="0059-STKG-001" href="#0059-STKG-001">0059-STKG-001</a>)
   - Delegate the locked tokens to one of the eligible validators (fixed set for Alpha mainnet).(<a name="0059-STKG-002" href="#0059-STKG-002">0059-STKG-002</a>)
 - These accounts will be created:
-  - A [staking account](./0013-ACCT-accounts.md#party-staking-accounts) denominated in the governance asset is created(<a name="0059-STKG-003" href="#0059-STKG-003">0059-STKG-003</a>)
+  - A [staking account](./0013-ACCT-accounts.md#staking-accounts) denominated in the governance asset is created(<a name="0059-STKG-003" href="#0059-STKG-003">0059-STKG-003</a>)
   - When first fees are received as a staking reward, a general account for each settlement currency (so they can receive infrastructure fee rewards) (<a name="0059-STKG-004" href="#0059-STKG-004">0059-STKG-004</a>)
   - It is possible that a separate reward function will cause an account to be created for the user as a result of rewards.
 - Timings
@@ -252,3 +252,9 @@ See the [network paramters spec](./0054-NETP-network_parameters.md#current-netwo
 - epoch 1: party associated 300 VEGA
 - end of epoch 1: according to the proportion of nomination, validators need to get 20,40,60,80,100 respectively - however max per validator implies availale balances of 100, 80, 60, 40, 20 for validators 1,2,3,4,5 respectively
 - meaning that at the following delegation will apply: 120, 240, 360, 440, 520. There will be no attempt to top up validators against the proportion implied by the nomination.
+
+# See also
+- [0013-ACCT Acccounts](./0013-ACCT-accounts.md) - staking accounts are not like other account types, but the differences are covered here.
+- [0028-GOVE Governance](./0028-GOVE-governance.md) - a party's stake controls their ability to participate in governance.
+- [0069-VALW Validators chosen by stake](./0069-VALW-validators_chosen_by_stake.md) - staking and delegation is used to pick validators.
+- [0050-EPOC Epochs](./0050-EPOC-epochs.md) - epochs control how frequently validator sets can change as a result of staking and delegation.


### PR DESCRIPTION
Staking accounts aren't really accounts in the same way as other
accounts, but they are referred to as accounts so I added a section that
clarifies this, and better linked together 0013-ACCT and 0059-STKG.

- Move 0013-ACCT acceptance criteria to the bottom
- Add See More section to 0059-STKG
- Add Staking Accounts section to 0013-ACCT

Closes #854
