### PR TITLE
Remove untestable ACs from 0046 DSRM

### DIFF
--- a/protocol/0046-DSRM-data_source_signed_message.md
+++ b/protocol/0046-DSRM-data_source_signed_message.md
@@ -109,10 +109,6 @@ Where possible, this should be done before the transaction is included in a bloc
     1. Contain correctly signed data from an active signed message data source,  (<a name="0046-DSRM-010" href="#0046-DSRM-010">0046-DSRM-010</a>)
     1. Invalid `SubmitData` transactions must be rejected.  (<a name="0046-DSRM-011" href="#0046-DSRM-011">0046-DSRM-011</a>)
 1. Must work with Coinbase oracle  (<a name="0046-DSRM-012" href="#0046-DSRM-012">0046-DSRM-012</a>)
-1. Reject any data source tx that is not explicitly required, so this would include a tx:
-    - For a pubkey never used in a data source  (<a name="0046-DSRM-013" href="#0046-DSRM-013">0046-DSRM-013</a>)
-    - For a data source where a filter rejects the message based on its contents  (<a name="0046-DSRM-014" href="#0046-DSRM-014">0046-DSRM-014</a>)
-    - For a pubkey only used in data sources referenced by markets (or other things) that are no longer being managed by the core (i.e. once a marked is in Closed or Settled or Cancelled state according to the market framework) or before the enactment date of the market proposal (<a name="0046-DSRM-015" href="#0046-DSRM-015">0046-DSRM-015</a>)
 1. Reject any SubmitData tx that is a duplicate (i.e. contains exactly the same data payload and is for the same data source), even if it is signed by a different signer (assuming the source has multiple configured signers) or was submitted by a different Vega key. (<a name="0046-DSRM-016" href="#0046-DSRM-016">0046-DSRM-016</a>)
 
 


### PR DESCRIPTION
Core rejects the messages as specified earlier in the spec file but doesn't actually produce any output saying "message rejected because no one cares about the pubkey (or the other criteria)". As such it's not obvious how to meaningfully test these ACs so I suggest removing. 