### PR TITLE
fix: remove deposit events to trigger checkpoints

### DIFF
--- a/non-protocol-specs/0005-NP-LIMN-limited_network_life.md
+++ b/non-protocol-specs/0005-NP-LIMN-limited_network_life.md
@@ -15,7 +15,7 @@ This is especially important early on when rapid iteration is desirable, as the 
 
 # Overview
 There are four main features:
-1. Create checkpoints with relevant (but minimal) information at regular intervals, and on every deposit and every withdrawal request.
+1. Create checkpoints with relevant (but minimal) information at regular intervals, and on every withdrawal request.
 2. Ability to specify a checkpoint hash as part of genesis.
 3. A new 'Restore' transaction that contains the full checkpoint file and triggers state restoration
 4. A new 'checkpoint hash' transaction is broadcast by all validators


### PR DESCRIPTION
Closes #1103

Its is not the case that deposit events should trigger checkpoints (only withdrawals).

This was found in testing: https://github.com/vegaprotocol/vega/issues/5363

The implementation was correct but the spec is outdated - this resolves the spec