### PR TITLE
Explicitly allow wash trading to leave an auction

### DIFF
--- a/protocol/0024-OSTA-order_status.md
+++ b/protocol/0024-OSTA-order_status.md
@@ -73,7 +73,8 @@ For a full outline of these behaviours, see [0037-OPEG-pegged_orders](./0037-OPE
 Note: The last row in the table above is added for clarity. If the order was filled, it is marked as Filled and it is removed from the book, so it can't expire after being filled.
 
 ## Wash trading
-If an order would be filled or partially filled with an existing order from the same [party](./0017-PART-party.md), the order is rejected. Any existing fills that happen before the wash trade is identified will be kept. FOK rules still apply for wash trading so if a wash trade is identified before the full amount of the order is complete, the order will be stopped and nothing filled.
+If, during continuous trading, an order would be filled or partially filled with an existing order from the same [party](./0017-PART-party.md) aka "wash" trade, the order is rejected. Any existing fills that happen before the wash trade is identified will be kept. FOK rules still apply for wash trading so if a wash trade is identified before the full amount of the order is complete, the order will be stopped and nothing filled.
+Wash trading is allowed on [auction](0026-AUCT-auctions.md) uncrossing. 
 
 | Filled State | Resulting status | Reason |
 |--------------|------------------|--------|

--- a/protocol/0025-OCRE-order_submission.md
+++ b/protocol/0025-OCRE-order_submission.md
@@ -7,7 +7,8 @@ To allow traders to interact with the market, they must be able to enter an orde
 - Orders can be submitted into any market that is active - i.e not in [a protective auction](./0026-AUCT-auctions.md) or [matured/expired/settled](./0043-MKTL-market_lifecycle.md).
 - Orders will only be accepted if sufficient margin can be allocated (see : [Margin Orchestration](./0010-MARG-margin_orchestration.md) and [Margin Calculator](./0019-MCAL-margin_calculator.md))
 - Amendments that change price or increase size will be executed as an atomic cancel/replace (i.e. as if the original order was cancelled and removed from the book and a new order submitted with the modified values - that is, time priority is lost)
-- Execution of an order during continuous trading will be stopped and the order cancelled and removed (if on the book) if it is about to match with another order on the book for the same party (that is, execution can proceed up to the point a "wash" trade would be generated but stopped before that and the order cancelled)
+- Execution of an order during continuous trading will be stopped and the order cancelled and removed (if on the book) if it is about to match with another order on the book for the same party (that is, execution can proceed up to the point a "wash" trade would be generated but stopped before that and the order cancelled).
+Self-trading / "wash" trading is allowed on auction uncrossing (i.e. to leave an auction).
 - Orders may be fractional in size with the maximum number of decimal places allowable being the `Position Decimal Places` specified in the [Market Framework](./0001-MKTF-market_framework.md), and any order containing more precision that this being rejected. (NB: orders may end up being specified as integers similar to how prices are, in which case this does not apply and 1 == the smallest increment given the configured position d.p.s for the market).
 
 

--- a/protocol/0068-MATC-matching_engine.md
+++ b/protocol/0068-MATC-matching_engine.md
@@ -34,6 +34,7 @@ Start date: 2021-12-14
        * [LIMIT](./0014-ORDT-order_types.md#order-pricing-methods) orders are placed into the book and no matching takes place. (<a name="0068-MATC-023" href="#0068-MATC-023">0068-MATC-023</a>) 
        * The indicative price and volume values are updated after every change to the order book. (<a name="0068-MATC-024" href="#0068-MATC-024">0068-MATC-024</a>) 
        * [PEGGED](./0014-ORDT-order_types.md#order-pricing-methods) orders are parked (and have their status set to PARKED). (<a name="0068-MATC-025" href="#0068-MATC-025">0068-MATC-025</a>) 
+       * It is possible to [self trade](./0024-OSTA-order_status.md#wash-trading) to uncross an auction. (<a name="0068-MATC-038" href="#0068-MATC-038">0068-MATC-038</a>) 
    * When a [market moves into an auction](./0026-AUCT-auctions.md#upon-entering-auction-mode):
      * All [PEGGED](./0014-ORDT-order_types.md#auction) orders are parked (and have their status set to PARKED). (<a name="0068-MATC-026" href="#0068-MATC-026">0068-MATC-026</a>) 
      * All [GFN](./0014-ORDT-order-types.md#time-in-force---validity) orders are cancelled. (<a name="0068-MATC-027" href="#0068-MATC-027">0068-MATC-027</a>) 


### PR DESCRIPTION
We are explicitly *not* allowing wash trades during continuous trading. 

Spec was not explicit about allowing wash trading during auctions. 