### PR TITLE
simplify multisig scores when excess signers, for now

### DIFF
--- a/protocol/0061-REWP-pos_rewards.md
+++ b/protocol/0061-REWP-pos_rewards.md
@@ -111,7 +111,7 @@ i.e., there is no anti-whaling function applied here (the penalties are removed)
 1. A validator called Bob leaves the set of tendermint validators (for example, reduce own plus delegated tokens so that their score is pushed down). A validator called Alice is promoted to tendermint validator set. 
 1. No-one updated multisig validators so we still have Bob's key on the list of multisig signer. 
 1. Epoch ends and multisig hasn't been updated.
-1. All validators and ersatz validators, apart from Alice get rewards, see [multisig-updates](0069-VCBS-validators_chosen_by_stake.md#multisig-updates-and-multisig-weight-updates-if-those-are-used).
+1. All Tendermint validators get no rewards. Ersatz validators still receive rewards.
 
 ## Rewards from trading fees are calculated and distributed (<a name="0061-REWP-007" href="#0061-REWP-007">0061-REWP-007</a>) 
 1. Run Vega with at least 3 tendermint validator nodes and at least 5 ersatz validator nodes each with different self-stake and delegation.

--- a/protocol/0069-VCBS-validators_chosen_by_stake.md
+++ b/protocol/0069-VCBS-validators_chosen_by_stake.md
@@ -86,11 +86,9 @@ In the reward calculation for the top `network.validators.multisig.numberOfSigne
 
 Thus a validator who is not there but should be has incentive to pay gas to update the multisig. Moreover a validator who's score has gone up substantially will want to do so as well. 
 
-As a consequence, if a potential validator joined the Vega chain validators but has *not* updated the Multisig members (and/or weights) then at the end of the epoch their score will be `0`. 
+As a consequence, if a potential validator joined the Vega chain validators but has *not* updated the Multisig members (and/or weights) then at the end of the epoch their score will be `0`. They will not get any rewards. 
 
-They will not get any rewards and at the start of the next epoch they will be removed from the validator set. 
-
-In the case where a node is removed due reduced delegation, or due to not meeting self-delegation criteria, or due to lack of performance, or due to a reduction in the value of `network.validators.tendermint.number`, the onus is on all of the remaining validators to remove the demoted member from the Multisig contract. They are incentivised to do so by all receiving a `validator_score` of `0` until the excess member is removed.
+In the case where a node is removed due reduced delegation, or due to not meeting self-delegation criteria, or due to lack of performance, or due to a reduction in the value of `network.validators.tendermint.number`, the onus is on all of the remaining validators to remove the demoted member from the Multisig contract. They are incentivised to do so by all receiving a `validator_score` of `0` *in the reward calculation* until the excess member is removed.
 
 Note that this could become obsolete if a future version of the protocol implements threshold signatures or another method that allows all validators to approve Ethereum actions. 
 

--- a/protocol/0069-VCBS-validators_chosen_by_stake.md
+++ b/protocol/0069-VCBS-validators_chosen_by_stake.md
@@ -90,6 +90,8 @@ As a consequence, if a potential validator joined the Vega chain validators but 
 
 They will not get any rewards and at the start of the next epoch they will be removed from the validator set. 
 
+In the case where a node is removed due to lack of performance, or due to a reduction in the value of `network.validators.tendermint.number`, the onus is on all of the remaining validators to remove the demoted member from the Multisig contract. They are incentivised to do so by all receiving a `validator_score` of `0` until the excess member is removed.
+
 Note that this could become obsolete if a future version of the protocol implements threshold signatures or another method that allows all validators to approve Ethereum actions. 
 
 
@@ -175,7 +177,7 @@ See [limited network life spec](../non-protocol-specs/0005-NP-LIMN-limited_netwo
   * Setup a network with 5 Tendermint validators but with only 4 validators that have sufficient self-delegation. Call the one without enough self-delegation Bob.
   * Announce a new node (Alice) and self-delegate to them, allow some time to replace the validator with no self-delegation (Bob) as a Tendermint validator by Alice. Note: At this point the signature of Bob IS still on the multisig contract. 
   * Transfer 1000 tokens to the VEGA reward account. 
-  * Verify that at the end of the epoch all of the validators *apart from Alice* should have a multisig score = 1. Alice has multisig score = 0. Alice will get no reward because she has not updated the smart contract info adding her signature and removing Bob. See [multisig updates](clarification-of-rewards-in-multisig-mismatch-case).
+  * Verify that at the end of the epoch all of the Tendermint validators should have a multisig score = 0 since Bob is still on the contract.
 3. Tendermint validators missing signature test 1 (<a name="0069-VCBS-012" href="#0069-VCBS-012">0069-VCBS-012</a>): 
   * Setup a network with 4 Tendermint validators with self-delegation and number of Tendermint validators net param set to 5. 
   * **Additional setup:** ensure that the network parameter network.validators.multisig.numberOfSigners is set to **5**.

--- a/protocol/0069-VCBS-validators_chosen_by_stake.md
+++ b/protocol/0069-VCBS-validators_chosen_by_stake.md
@@ -90,7 +90,7 @@ As a consequence, if a potential validator joined the Vega chain validators but 
 
 They will not get any rewards and at the start of the next epoch they will be removed from the validator set. 
 
-In the case where a node is removed due to lack of performance, or due to a reduction in the value of `network.validators.tendermint.number`, the onus is on all of the remaining validators to remove the demoted member from the Multisig contract. They are incentivised to do so by all receiving a `validator_score` of `0` until the excess member is removed.
+In the case where a node is removed due reduced delegation, or due to not meeting self-delegation criteria, or due to lack of performance, or due to a reduction in the value of `network.validators.tendermint.number`, the onus is on all of the remaining validators to remove the demoted member from the Multisig contract. They are incentivised to do so by all receiving a `validator_score` of `0` until the excess member is removed.
 
 Note that this could become obsolete if a future version of the protocol implements threshold signatures or another method that allows all validators to approve Ethereum actions. 
 


### PR DESCRIPTION
In relation to what was discussed here: https://vegaprotocol.slack.com/archives/CAHA5EX0F/p1655714422071649

Simplifies the mutlisig scores when signatures are in excess. 