### PR TITLE
Remove API acceptance criteria in 0026-AUCT

### DIFF
--- a/protocol/0026-AUCT-auctions.md
+++ b/protocol/0026-AUCT-auctions.md
@@ -177,5 +177,4 @@ message Market {
 - As an API user, I can identify: (<a name="0026-AUCT-008" href="#0026-AUCT-008">0026-AUCT-008</a>)
   - If a market is temporarily in an auction period
   - Why it is in that period (e.g. Auction at open, liquidity sourcing)
-  - What price mode that auction will use when the auction is over
   - When the auction mode ends


### PR DESCRIPTION
There is only one uncrossing mode, so there is no need for an API to describe what we're using