### PR TITLE
Fix for untestable step in 0069-VCBS-042 

### DIFF
--- a/protocol/0069-VCBS-validators_chosen_by_stake.md
+++ b/protocol/0069-VCBS-validators_chosen_by_stake.md
@@ -328,7 +328,7 @@ See [limited network life spec](./0073-LIMN-limited_network_life.md).
 9. Swap due to better score (<a name="0069-VCBS-042" href="#0069-VCBS-042">0069-VCBS-042</a>):
   * Setup a network with 5 Tendermint validators and self-delegate 1000 tokens to each of them. 
   * Announce a new node at the beginning of the epoch, self-delegate to them a total that is 10000 tokens. 
-  * At the beginning of the next epoch the new validator should have ranking score *equal or lower* to all of the Tendermint validators so it doesn’t get promoted. 
+  * At the beginning of the next epoch the new validator should have ranking score *equal* to all of the Tendermint validators so it doesn’t get promoted. 
   * In the middle of the epoch, shut node 1 down. 
   * Verify that at the beginning of the next epoch the announced node replaced node 1 as a Tendermint validator. 
   * Restart node 1 again from a snapshot


### PR DESCRIPTION
Reverts vegaprotocol/specs#1198

As per @wwestgarth the above PR hasn't fixed the issue:https://github.com/vegaprotocol/specs/pull/1198#discussion_r952776108 

So let's get it right this time. 