### PR TITLE
User interface AC tweaks

### DIFF
--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -7,7 +7,7 @@ A wallet can contain many public/private key pairs. The public part of each key 
 When on the wallet page of Vega.xyz, I...
 
 - **must** see links to the latest version of the desktop and command line wallets (inc github repos) (<a name="0001-WALL-001" href="#0001-WALL-001">0001-WALL-001</a>)
-- **must** see a primary download button is configured for the latest version and the operating system I am using (<a name="0001-WALL-002" href="#0001-WALL-002">0001-WALL-002</a>)
+- **must** be able to easily download the latest version for the operating system I am using (<a name="0001-WALL-002" href="#0001-WALL-002">0001-WALL-002</a>)
 - **must** be able to use the default wallet version linked/downloadable from this page with the version of Vega currently running on mainnet (<a name="0001-WALL-076" href="#0001-WALL-076">0001-WALL-076</a>)
 
 ...so I can download and run the wallet app on my machine and use it to interact with the Vega mainnet

--- a/user-interface/0002-WCON-connect_vega_wallet.md
+++ b/user-interface/0002-WCON-connect_vega_wallet.md
@@ -6,6 +6,7 @@ When looking to use Vega via a user interface e.g. Dapp (Decentralized web App),
 
 - **should** see a link to get a Vega wallet (in case I don't already have one) (<a name="0002-WCON-036" href="#0002-WCON-036">0002-WCON-036</a>)
 - **should** see a link to connect that opens up connection options (<a name="0002-WCON-001" href="#0002-WCON-001">0002-WCON-001</a>)
+- **should** have a way to easily access help should I need to troubleshoot my connection e.g. link to the docs
 - **must** select a connection method / wallet type: (<a name="0002-WCON-002" href="#0002-WCON-002">0002-WCON-002</a>)
 - if Rest:
   - **must** have the option to input a non-default Wallet location (<a name="0002-WCON-003" href="#0002-WCON-003">0002-WCON-003</a>)

--- a/user-interface/6001-SORD-submit_orders.md
+++ b/user-interface/6001-SORD-submit_orders.md
@@ -7,7 +7,7 @@ When populating a deal ticket I...
   - **must** see the current market trading mode (Continuous, Auction etc) (<a name="6001-SORD-002" href="#6001-SORD-002">6001-SORD-002</a>)
 
 - If I have a 0 total balance of the settlement asset: **must** be warned that I have insufficient collateral (but also allow you to populate ticket because I might want to try before I deposit) (<a name="6001-SORD-003" href="#6001-SORD-003">6001-SORD-003</a>)
-  - **should** see a link to deposit the required collateral (<a name="6001-SORD-050" href="#6001-SORD-050">6001-SORD-050</a>)
+  - **should** have a way to easily deposit the required collateral (<a name="6001-SORD-050" href="#6001-SORD-050">6001-SORD-050</a>)
 
 - **must** select a side/direction e.g. long/short (note: some implementations may do this with two different submit buttons long/short rather than a toggle) (<a name="6001-SORD-004" href="#6001-SORD-004">6001-SORD-004</a>)
 
@@ -22,8 +22,8 @@ When populating a deal ticket I...
 ...need to select a size, when selecting a size for my order, I...
 
 - **must** input an order [size](7001-DATA-data_display.md#size) (aka amount or contracts) (<a name="6001-SORD-010" href="#6001-SORD-010">6001-SORD-010</a>)
-  - **should** have the previous value for the selected market pre-populated (last submitted or last changed) (<a name="6001-SORD-012" href="#6001-SORD-012">6001-SORD-012</a>)
-  - **should** be able to hit up/down on the keyboard to increase the size by the market's min-contract size (<a name="6001-SORD-013" href="#6001-SORD-013">6001-SORD-013</a>)
+  - **should** have the previous value for the selected market available e.g. pre-populated (last submitted or last changed) (<a name="6001-SORD-012" href="#6001-SORD-012">6001-SORD-012</a>)
+  - **should** be able to quickly tweak the size by the market's min-contract size e.g. hit up/down on the keyboard to increase (<a name="6001-SORD-013" href="#6001-SORD-013">6001-SORD-013</a>)
     - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows (<a name="6001-SORD-054" href="#6001-SORD-054">6001-SORD-054</a>)
     - **would like to** be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc. (<a name="6001-SORD-056" href="#6001-SORD-056">6001-SORD-056</a>)
   - TODO **would** like to be able to use use a leverage slider to determine a size based on how much leverage I wish to use (given general balance, price input/current price) <!-- (<a name="6001-SORD-015" href="#6001-SORD-015">6001-SORD-015</a>) -->


### PR DESCRIPTION
Small tweak to make the wording of downloading the wallet from .xyz less solution specific (we might need to change the solution there)

Added - **should** have a way to easily access help should I need to troubleshoot my connection e.g. link to the docs (needs a link attached to it)

Then on Update 6001-SORD-submit_orders.md...

A lot of this feels quite specific to the solution, but it also might not be worth changing this now if this is expected behaviour based on how users expect an exchange to work? 

For example:
input field pre-populated -> ... have the previous value for the selected market available e.g. pre-populated
hit up/down on the keyboard to increase -> ... be able to quickly tweak the size by the market's min-contract size e.g. hit up/down on the keyboard to increase

