### PR TITLE
User interface: Add `MORD` Manage orders content

### DIFF
--- a/user-interface/6000-COLL-collateral.md
+++ b/user-interface/6000-COLL-collateral.md
@@ -1,1 +1,0 @@
-# Collateral / accounts

--- a/user-interface/7002-SORD-submit_orders.md
+++ b/user-interface/7002-SORD-submit_orders.md
@@ -114,7 +114,7 @@ When populating a deal ticket I...
 ... need to submit my order, when submitting my order, I... 
 
 - if not already connected: **must** see a prompt to [connect a Vega wallet](0002-WCON-connect_vega_wallet.md)
-- **must** submit the [Vega submit order transaction](0013-WTXN-submit_vega_transaction.md). (<a name="6001-SORD-039" href="#6001-SORD-039">6001-SORD-039</a>)
+- **must** submit the [Vega submit order transaction](0003-WTXN-submit_vega_transaction.md). (<a name="6001-SORD-039" href="#6001-SORD-039">6001-SORD-039</a>)
 
 - **must** see feedback on my order [status](https://docs.vega.xyz/docs/mainnet/grpc/vega/vega.proto#orderstatus) (not just transaction status above) (<a name="6001-SORD-040" href="#6001-SORD-040">6001-SORD-040</a>)
   - Active (aka Open) (<a name="6001-SORD-041" href="#6001-SORD-041">6001-SORD-041</a>)

--- a/user-interface/7002-SORD-submit_orders.md
+++ b/user-interface/7002-SORD-submit_orders.md
@@ -5,17 +5,17 @@ As a user I want change my exposure on a market (e.g. open a position, increase 
 
 When populating a deal ticket I...
 
-- **must** see/select the [Market](./DATA-data_display.md#market) I am submitting the order for (<a name="6001-SORD-001" href="#6001-SORD-001">6001-SORD-001</a>)
-  - **must** see the current market trading mode (Continuous, Auction etc) (<a name="6001-SORD-002" href="#6001-SORD-002">6001-SORD-002</a>)
+- **must** see/select the [Market](./DATA-data_display.md#market) I am submitting the order for (<a name="7002-SORD-001" href="#7002-SORD-001">7002-SORD-001</a>)
+  - **must** see the current market trading mode (Continuous, Auction etc) (<a name="7002-SORD-002" href="#7002-SORD-002">7002-SORD-002</a>)
 
-- If I have a 0 total balance of the settlement asset: **must** be warned that I have insufficient collateral (but also allow you to populate ticket because I might want to try before I deposit) (<a name="6001-SORD-003" href="#6001-SORD-003">6001-SORD-003</a>)
-  - **should** have a way to easily deposit the required collateral (<a name="6001-SORD-050" href="#6001-SORD-050">6001-SORD-050</a>)
+- If I have a 0 total balance of the settlement asset: **must** be warned that I have insufficient collateral (but also allow you to populate ticket because I might want to try before I deposit) (<a name="7002-SORD-003" href="#7002-SORD-003">7002-SORD-003</a>)
+  - **should** have a way to easily deposit the required collateral (<a name="7002-SORD-050" href="#7002-SORD-050">7002-SORD-050</a>)
 
-- **must** select a side/direction e.g. long/short (note: some implementations may do this with two different submit buttons long/short rather than a toggle) (<a name="6001-SORD-004" href="#6001-SORD-004">6001-SORD-004</a>)
+- **must** select a side/direction e.g. long/short (note: some implementations may do this with two different submit buttons long/short rather than a toggle) (<a name="7002-SORD-004" href="#7002-SORD-004">7002-SORD-004</a>)
 
-- **must** be able to select the [order type](../protocol/0014-ORDT-order_types.md) that I wish to submit (<a name="6001-SORD-005" href="#6001-SORD-005">6001-SORD-005</a>)
-  - **must** see limit order (<a name="6001-SORD-006" href="#6001-SORD-006">6001-SORD-006</a>)
-  - **must** see market order (<a name="6001-SORD-007" href="#6001-SORD-007">6001-SORD-007</a>)
+- **must** be able to select the [order type](../protocol/0014-ORDT-order_types.md) that I wish to submit (<a name="7002-SORD-005" href="#7002-SORD-005">7002-SORD-005</a>)
+  - **must** see limit order (<a name="7002-SORD-006" href="#7002-SORD-006">7002-SORD-006</a>)
+  - **must** see market order (<a name="7002-SORD-007" href="#7002-SORD-007">7002-SORD-007</a>)
   - **should** see pegged order
   - **should** see liquidity provision 
 
@@ -23,12 +23,12 @@ When populating a deal ticket I...
 
 ...need to select a size, when selecting a size for my order, I...
 
-- **must** input an order [size](DATA-data_display.md#size) (aka amount or contracts) (<a name="6001-SORD-010" href="#6001-SORD-010">6001-SORD-010</a>)
-  - **should** have the previous value for the selected market available e.g. pre-populated (last submitted or last changed) (<a name="6001-SORD-012" href="#6001-SORD-012">6001-SORD-012</a>)
-  - **should** be able to quickly change the size by the market's min-contract size e.g. hit up/down on the keyboard to increase (<a name="6001-SORD-013" href="#6001-SORD-013">6001-SORD-013</a>)
-    - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows (<a name="6001-SORD-054" href="#6001-SORD-054">6001-SORD-054</a>)
-    - **would like to** be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc. (<a name="6001-SORD-056" href="#6001-SORD-056">6001-SORD-056</a>)
-- **must** be warned (pre-submit) if input has too many digits after the decimal place for the market's ["position" decimal places](DATA-data_display.md#size) (<a name="6001-SORD-016" href="#6001-SORD-016">6001-SORD-016</a>) 
+- **must** input an order [size](DATA-data_display.md#size) (aka amount or contracts) (<a name="7002-SORD-010" href="#7002-SORD-010">7002-SORD-010</a>)
+  - **should** have the previous value for the selected market available e.g. pre-populated (last submitted or last changed) (<a name="7002-SORD-012" href="#7002-SORD-012">7002-SORD-012</a>)
+  - **should** be able to quickly change the size by the market's min-contract size e.g. hit up/down on the keyboard to increase (<a name="7002-SORD-013" href="#7002-SORD-013">7002-SORD-013</a>)
+    - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows (<a name="7002-SORD-054" href="#7002-SORD-054">7002-SORD-054</a>)
+    - **would like to** be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc. (<a name="7002-SORD-056" href="#7002-SORD-056">7002-SORD-056</a>)
+- **must** be warned (pre-submit) if input has too many digits after the decimal place for the market's ["position" decimal places](DATA-data_display.md#size) (<a name="7002-SORD-016" href="#7002-SORD-016">7002-SORD-016</a>) 
 
 ... so I get the size of exposure (open volume that I want)
 
@@ -36,14 +36,14 @@ When populating a deal ticket I...
 
 ... if wanting to place a limit on the price that I trade at, I...
 
-- **must** enter a [price](DATA-data_display.md#quote-price). (<a name="6001-SORD-017" href="#6001-SORD-017">6001-SORD-017</a>) 
-- **must** see the price unit (as defined in market) (<a name="6001-SORD-018" href="#6001-SORD-018">6001-SORD-018</a>)
-  - **should** be able quickly pre-populate the price with the current mark price (if there is one, 0 if not) e.g. by focusing the input and hitting up/down (<a name="6001-SORD-011" href="#6001-SORD-011">6001-SORD-011</a>)
-  - **should** have the previous value for the selected market pre-populated (last submitted or last changed) (<a name="6001-SORD-014" href="#6001-SORD-014">6001-SORD-014</a>)
-  - **should** be able to hit up/down on the keyboard to increase the price by the market's tick size (if set, or smallest increment) (<a name="6001-SORD-051" href="#6001-SORD-051">6001-SORD-051</a>)
-    - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows (<a name="6001-SORD-055" href="#6001-SORD-055">6001-SORD-055</a>)
-    - **would like to** be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc. (<a name="6001-SORD-057" href="#6001-SORD-057">6001-SORD-057</a>)
-- **must** be warned (pre-submit) if the input price has too many digits after the decimal place for the market ["quote"](DATA-data_display.md#quote-price) (<a name="6001-SORD-059" href="#6001-SORD-059">6001-SORD-059</a>)
+- **must** enter a [price](DATA-data_display.md#quote-price). (<a name="7002-SORD-017" href="#7002-SORD-017">7002-SORD-017</a>) 
+- **must** see the price unit (as defined in market) (<a name="7002-SORD-018" href="#7002-SORD-018">7002-SORD-018</a>)
+  - **should** be able quickly pre-populate the price with the current mark price (if there is one, 0 if not) e.g. by focusing the input and hitting up/down (<a name="7002-SORD-011" href="#7002-SORD-011">7002-SORD-011</a>)
+  - **should** have the previous value for the selected market pre-populated (last submitted or last changed) (<a name="7002-SORD-014" href="#7002-SORD-014">7002-SORD-014</a>)
+  - **should** be able to hit up/down on the keyboard to increase the price by the market's tick size (if set, or smallest increment) (<a name="7002-SORD-051" href="#7002-SORD-051">7002-SORD-051</a>)
+    - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows (<a name="7002-SORD-055" href="#7002-SORD-055">7002-SORD-055</a>)
+    - **would like to** be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc. (<a name="7002-SORD-057" href="#7002-SORD-057">7002-SORD-057</a>)
+- **must** be warned (pre-submit) if the input price has too many digits after the decimal place for the market ["quote"](DATA-data_display.md#quote-price) (<a name="7002-SORD-059" href="#7002-SORD-059">7002-SORD-059</a>)
 
 ... so that my order only trades at up/down to a particular price
 
@@ -51,8 +51,8 @@ When populating a deal ticket I...
 
 ... if wanting to trade regardless of price (or assuming that the market is liquid enough that the current best prices are enough of an indication of the price I'll get)...
 
-- **must not** see a price input (<a name="6001-SORD-019" href="#6001-SORD-019">6001-SORD-019</a>)
-- **should** be warning if the market is in auction and the market order may be rejected (<a name="6001-SORD-052" href="#6001-SORD-052">6001-SORD-052</a>)
+- **must not** see a price input (<a name="7002-SORD-019" href="#7002-SORD-019">7002-SORD-019</a>)
+- **should** be warning if the market is in auction and the market order may be rejected (<a name="7002-SORD-052" href="#7002-SORD-052">7002-SORD-052</a>)
 
 ... so I can quickly submit an order without populating the ticket with elements I don't care about
 
@@ -69,16 +69,16 @@ When populating a deal ticket I...
 ... should to select a time in force, when selecting a time in force, I...
 
 - **must** select a time in force
-  - Good till canceled `GTC` - not applicable to Market orders (<a name="6001-SORD-023" href="#6001-SORD-023">6001-SORD-023</a>)
-  - Good till time `GTT` - not applicable to Market orders (<a name="6001-SORD-024" href="#6001-SORD-024">6001-SORD-024</a>)
-  - Fill or kill `FOK` (<a name="6001-SORD-025" href="#6001-SORD-025">6001-SORD-025</a>)
-  - Immediate or cancel `IOC` (<a name="6001-SORD-026" href="#6001-SORD-026">6001-SORD-026</a>)
-  - Good for normal trading only `GFN` - not applicable to Market orders (<a name="6001-SORD-027" href="#6001-SORD-027">6001-SORD-027</a>)
-  - Good for auction only `GFA` - not applicable to Market orders (<a name="6001-SORD-028" href="#6001-SORD-028">6001-SORD-028</a>)
-- **should** only be warned if the time in force is not applicable to the order type I have selected (<a name="6001-SORD-029" href="#6001-SORD-029">6001-SORD-029</a>)
-- **should** only be warned if the time in force is not applicable to current period's trading mode (<a name="6001-SORD-058" href="#6001-SORD-058">6001-SORD-058</a>)
-- if the user has not set a preference: market orders **should** default to `IOC` (<a name="6001-SORD-030" href="#6001-SORD-030">6001-SORD-030</a>)
-- if the user has not set a preference: limit orders **should** default to `GTC` (<a name="6001-SORD-031" href="#6001-SORD-031">6001-SORD-031</a>)
+  - Good till canceled `GTC` - not applicable to Market orders (<a name="7002-SORD-023" href="#7002-SORD-023">7002-SORD-023</a>)
+  - Good till time `GTT` - not applicable to Market orders (<a name="7002-SORD-024" href="#7002-SORD-024">7002-SORD-024</a>)
+  - Fill or kill `FOK` (<a name="7002-SORD-025" href="#7002-SORD-025">7002-SORD-025</a>)
+  - Immediate or cancel `IOC` (<a name="7002-SORD-026" href="#7002-SORD-026">7002-SORD-026</a>)
+  - Good for normal trading only `GFN` - not applicable to Market orders (<a name="7002-SORD-027" href="#7002-SORD-027">7002-SORD-027</a>)
+  - Good for auction only `GFA` - not applicable to Market orders (<a name="7002-SORD-028" href="#7002-SORD-028">7002-SORD-028</a>)
+- **should** only be warned if the time in force is not applicable to the order type I have selected (<a name="7002-SORD-029" href="#7002-SORD-029">7002-SORD-029</a>)
+- **should** only be warned if the time in force is not applicable to current period's trading mode (<a name="7002-SORD-058" href="#7002-SORD-058">7002-SORD-058</a>)
+- if the user has not set a preference: market orders **should** default to `IOC` (<a name="7002-SORD-030" href="#7002-SORD-030">7002-SORD-030</a>)
+- if the user has not set a preference: limit orders **should** default to `GTC` (<a name="7002-SORD-031" href="#7002-SORD-031">7002-SORD-031</a>)
 
 ... so I can control if and how my order stays on the order book
 
@@ -93,19 +93,19 @@ When populating a deal ticket I...
 ## See the potential consequences of an order before it is submit
 ... based on the current inputs I'd like an indication of the consequences of my order based on my position and the state of the market, I...
 
-- **could** see my resulting open volume (<a name="6001-SORD-032" href="#6001-SORD-032">6001-SORD-032</a>)
+- **could** see my resulting open volume (<a name="7002-SORD-032" href="#7002-SORD-032">7002-SORD-032</a>)
 - **could** see the amount this order might move the market in percentage terms
 - **could** see what the new best prices of the market would be after placing this order (assuming my order moves the market)
-- **could** see new volume weighted average entry price if not 0 (<a name="6001-SORD-033" href="#6001-SORD-033">6001-SORD-033</a>)
+- **could** see new volume weighted average entry price if not 0 (<a name="7002-SORD-033" href="#7002-SORD-033">7002-SORD-033</a>)
 - **could** see and indication the volume weighted price that this particular order 
 - **could** see an indication of how much of the order will trade when it hits the book and how much might remain passive
-- **could** see a new liquidation level (<a name="6001-SORD-034" href="#6001-SORD-034">6001-SORD-034</a>)
-- **could** see an estimate of the fees that will be paid (if any) (<a name="6001-SORD-035" href="#6001-SORD-035">6001-SORD-035</a>)
+- **could** see a new liquidation level (<a name="7002-SORD-034" href="#7002-SORD-034">7002-SORD-034</a>)
+- **could** see an estimate of the fees that will be paid (if any) (<a name="7002-SORD-035" href="#7002-SORD-035">7002-SORD-035</a>)
 - **could** see my "position leverage" TODO - define this
 - **could** see my "account leverage" TODO - define this 
-- **could** see an amount of realized Profit / Loss (<a name="6001-SORD-036" href="#6001-SORD-036">6001-SORD-036</a>)
-- **could** see any change in margin requirements (if more or less margin will be required) (<a name="6001-SORD-037" href="#6001-SORD-037">6001-SORD-037</a>)
-- **could** see the notional value of my order (<a name="6001-SORD-038" href="#6001-SORD-038">6001-SORD-038</a>)
+- **could** see an amount of realized Profit / Loss (<a name="7002-SORD-036" href="#7002-SORD-036">7002-SORD-036</a>)
+- **could** see any change in margin requirements (if more or less margin will be required) (<a name="7002-SORD-037" href="#7002-SORD-037">7002-SORD-037</a>)
+- **could** see the notional value of my order (<a name="7002-SORD-038" href="#7002-SORD-038">7002-SORD-038</a>)
 
 ... so that I can adjust my inputs before submitting
 
@@ -114,19 +114,19 @@ When populating a deal ticket I...
 ... need to submit my order, when submitting my order, I... 
 
 - if not already connected: **must** see a prompt to [connect a Vega wallet](0002-WCON-connect_vega_wallet.md)
-- **must** submit the [submit order Vega transaction](0003-WTXN-submit_vega_transaction.md). (<a name="6001-SORD-039" href="#6001-SORD-039">6001-SORD-039</a>)
+- **must** submit the [submit order Vega transaction](0003-WTXN-submit_vega_transaction.md). (<a name="7002-SORD-039" href="#7002-SORD-039">7002-SORD-039</a>)
 
-- **must** see feedback on my order [status](https://docs.vega.xyz/docs/mainnet/grpc/vega/vega.proto#orderstatus) (not just transaction status above) (<a name="6001-SORD-040" href="#6001-SORD-040">6001-SORD-040</a>)
-  - Active (aka Open) (<a name="6001-SORD-041" href="#6001-SORD-041">6001-SORD-041</a>)
-  - Expired (<a name="6001-SORD-042" href="#6001-SORD-042">6001-SORD-042</a>)
-  - Cancelled. Should see the txn that cancelled it and a link to the block explorer, if cancelled by a user transaction. (<a name="6001-SORD-043" href="#6001-SORD-043">6001-SORD-043</a>)
-  - Stopped. **should** see an explanation of why stopped (<a name="6001-SORD-044" href="#6001-SORD-044">6001-SORD-044</a>)
-  - Partially filled. **should** see how much of the [size](DATA-data_display.md#size) if filled/remaining (<a name="6001-SORD-045" href="#6001-SORD-045">6001-SORD-045</a>)
-  - Filled. Must be able to see/link to all trades that were created from this order. (<a name="6001-SORD-046" href="#6001-SORD-046">6001-SORD-046</a>)
-  - Rejected: **must** see the reason it was rejected (<a name="6001-SORD-047" href="#6001-SORD-047">6001-SORD-047</a>)
-  - Parked: **should** see an explanation of why parked orders happen (<a name="6001-SORD-048" href="#6001-SORD-048">6001-SORD-048</a>)
-- All feedback must be a subscription so is updated as the status changes (<a name="6001-SORD-053" href="#6001-SORD-053">6001-SORD-053</a>)
- - **could** repeat the values that were submitted (order type + all fields) (<a name="6001-SORD-049" href="#6001-SORD-049">6001-SORD-049</a>)
+- **must** see feedback on my order [status](https://docs.vega.xyz/docs/mainnet/grpc/vega/vega.proto#orderstatus) (not just transaction status above) (<a name="7002-SORD-040" href="#7002-SORD-040">7002-SORD-040</a>)
+  - Active (aka Open) (<a name="7002-SORD-041" href="#7002-SORD-041">7002-SORD-041</a>)
+  - Expired (<a name="7002-SORD-042" href="#7002-SORD-042">7002-SORD-042</a>)
+  - Cancelled. Should see the txn that cancelled it and a link to the block explorer, if cancelled by a user transaction. (<a name="7002-SORD-043" href="#7002-SORD-043">7002-SORD-043</a>)
+  - Stopped. **should** see an explanation of why stopped (<a name="7002-SORD-044" href="#7002-SORD-044">7002-SORD-044</a>)
+  - Partially filled. **should** see how much of the [size](DATA-data_display.md#size) if filled/remaining (<a name="7002-SORD-045" href="#7002-SORD-045">7002-SORD-045</a>)
+  - Filled. Must be able to see/link to all trades that were created from this order. (<a name="7002-SORD-046" href="#7002-SORD-046">7002-SORD-046</a>)
+  - Rejected: **must** see the reason it was rejected (<a name="7002-SORD-047" href="#7002-SORD-047">7002-SORD-047</a>)
+  - Parked: **should** see an explanation of why parked orders happen (<a name="7002-SORD-048" href="#7002-SORD-048">7002-SORD-048</a>)
+- All feedback must be a subscription so is updated as the status changes (<a name="7002-SORD-053" href="#7002-SORD-053">7002-SORD-053</a>)
+ - **could** repeat the values that were submitted (order type + all fields) (<a name="7002-SORD-049" href="#7002-SORD-049">7002-SORD-049</a>)
 
 ... so that I am aware of the status of my order before seeing it in the [orders table](6002-MORD-manage_orders.md).
 

--- a/user-interface/7002-SORD-submit_orders.md
+++ b/user-interface/7002-SORD-submit_orders.md
@@ -114,7 +114,7 @@ When populating a deal ticket I...
 ... need to submit my order, when submitting my order, I... 
 
 - if not already connected: **must** see a prompt to [connect a Vega wallet](0002-WCON-connect_vega_wallet.md)
-- **must** submit the [Vega submit order transaction](0003-WTXN-submit_vega_transaction.md). (<a name="6001-SORD-039" href="#6001-SORD-039">6001-SORD-039</a>)
+- **must** submit the [submit order Vega transaction](0003-WTXN-submit_vega_transaction.md). (<a name="6001-SORD-039" href="#6001-SORD-039">6001-SORD-039</a>)
 
 - **must** see feedback on my order [status](https://docs.vega.xyz/docs/mainnet/grpc/vega/vega.proto#orderstatus) (not just transaction status above) (<a name="6001-SORD-040" href="#6001-SORD-040">6001-SORD-040</a>)
   - Active (aka Open) (<a name="6001-SORD-041" href="#6001-SORD-041">6001-SORD-041</a>)

--- a/user-interface/7002-SORD-submit_orders.md
+++ b/user-interface/7002-SORD-submit_orders.md
@@ -1,49 +1,81 @@
 # Submit order
 As a user I want change my exposure on a market (e.g. open a position, increase or decrease my open volume), I want to submit an order with instructions for how my order should be executed so I have some control over the price that I get, as well as if when/my order should stay on the book. See [specs about orders](../protocol#orders) for more info.
 
+## Before seeing a "deal ticket"
+
+When looking at a market, I...
+
+- **must** see/select the [Market](./7001-DATA-data_display.md#market) I am submitting the order for (<a name="7002-SORD-001" href="#7002-SORD-001">7002-SORD-001</a>)
+- **must** see the current `status` of the market (<a name="7002-SORD-061" href="#7002-SORD-061">7002-SORD-061</a>)
+  
+  if the market is in a state of `rejected`, `canceled` or `closed`:
+
+  - **must** see that the market is not accepting orders and never will be (<a name="7002-SORD-062" href="#7002-SORD-062">7002-SORD-062</a>)
+  
+  if the market is in a state of `tradingTerminated`:
+
+  - **must** see that the market is not accepting orders and never will be (<a name="7002-SORD-063" href="#7002-SORD-063">7002-SORD-063</a>)
+  - **should** see the [price](7001-DATA-data_display.md#quote-price) that was used to settle the market
+  - **should** see a link to oracle spec and data
+
+  if the market is in a state of `settled`:
+
+  - **must** see that the market is not accepting orders and never will be (<a name="7002-SORD-066" href="#7002-SORD-066">7002-SORD-066</a>)
+  - **should** see the oracle events that terminated the market
+  - **should** see a link to oracle spec and data
+
+  if the market is in a state of `suspended`:
+  
+  - **should** see what suspended the market
+  - **should** see the conditioned required for the auction to end
+  - **should** see the current data values that the auction end is measured against (e.g. Supplied stake)
+
+...so I know if the market is accepting orders.
+
+The rest of this document only applies if the state of the market is `pending`, `active` or `suspended`:
+
 ## Deal ticket
 
 When populating a deal ticket I...
 
-- **must** see/select the [Market](./DATA-data_display.md#market) I am submitting the order for (<a name="7002-SORD-001" href="#7002-SORD-001">7002-SORD-001</a>)
-  - **must** see the current market trading mode (Continuous, Auction etc) (<a name="7002-SORD-002" href="#7002-SORD-002">7002-SORD-002</a>)
+- **must** see the current market trading mode (Continuous, Auction etc) (<a name="7002-SORD-002" href="#7002-SORD-002">7002-SORD-002</a>)
 
 - If I have a 0 total balance of the settlement asset: **must** be warned that I have insufficient collateral (but also allow you to populate ticket because I might want to try before I deposit) (<a name="7002-SORD-003" href="#7002-SORD-003">7002-SORD-003</a>)
-  - **should** have a way to easily deposit the required collateral (<a name="7002-SORD-050" href="#7002-SORD-050">7002-SORD-050</a>)
+  - **should** have a way to easily deposit the required collateral
 
 - **must** select a side/direction e.g. long/short (note: some implementations may do this with two different submit buttons long/short rather than a toggle) (<a name="7002-SORD-004" href="#7002-SORD-004">7002-SORD-004</a>)
 
 - **must** be able to select the [order type](../protocol/0014-ORDT-order_types.md) that I wish to submit (<a name="7002-SORD-005" href="#7002-SORD-005">7002-SORD-005</a>)
   - **must** see limit order (<a name="7002-SORD-006" href="#7002-SORD-006">7002-SORD-006</a>)
   - **must** see market order (<a name="7002-SORD-007" href="#7002-SORD-007">7002-SORD-007</a>)
-  - **should** see pegged order
+  - **should** see pegged order 
   - **should** see liquidity provision 
 
 ## Order size
 
 ...need to select a size, when selecting a size for my order, I...
 
-- **must** input an order [size](DATA-data_display.md#size) (aka amount or contracts) (<a name="7002-SORD-010" href="#7002-SORD-010">7002-SORD-010</a>)
-  - **should** have the previous value for the selected market available e.g. pre-populated (last submitted or last changed) (<a name="7002-SORD-012" href="#7002-SORD-012">7002-SORD-012</a>)
-  - **should** be able to quickly change the size by the market's min-contract size e.g. hit up/down on the keyboard to increase (<a name="7002-SORD-013" href="#7002-SORD-013">7002-SORD-013</a>)
-    - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows (<a name="7002-SORD-054" href="#7002-SORD-054">7002-SORD-054</a>)
-    - **would like to** be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc. (<a name="7002-SORD-056" href="#7002-SORD-056">7002-SORD-056</a>)
-- **must** be warned (pre-submit) if input has too many digits after the decimal place for the market's ["position" decimal places](DATA-data_display.md#size) (<a name="7002-SORD-016" href="#7002-SORD-016">7002-SORD-016</a>) 
+- **must** input an order [size](7001-DATA-data_display.md#size) (aka amount or contracts) (<a name="7002-SORD-010" href="#7002-SORD-010">7002-SORD-010</a>)
+  - **should** have the previous value for the selected market available e.g. pre-populated (last submitted or last changed)
+  - **should** be able to quickly change the size by the market's min-contract size e.g. hit up/down on the keyboard to increase
+    - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows
+    - **would** like to be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc. 
+- **must** be warned (pre-submit) if input has too many digits after the decimal place for the market's ["position" decimal places](7001-DATA-data_display.md#size) (<a name="7002-SORD-016" href="#7002-SORD-016">7002-SORD-016</a>) 
 
-... so I get the size of exposure (open volume that I want)
+... so I get the size of exposure (open volume) that I want
 
 ## Price - Limit order
 
 ... if wanting to place a limit on the price that I trade at, I...
 
-- **must** enter a [price](DATA-data_display.md#quote-price). (<a name="7002-SORD-017" href="#7002-SORD-017">7002-SORD-017</a>) 
+- **must** enter a [price](7001-DATA-data_display.md#quote-price). (<a name="7002-SORD-017" href="#7002-SORD-017">7002-SORD-017</a>) 
 - **must** see the price unit (as defined in market) (<a name="7002-SORD-018" href="#7002-SORD-018">7002-SORD-018</a>)
-  - **should** be able quickly pre-populate the price with the current mark price (if there is one, 0 if not) e.g. by focusing the input and hitting up/down (<a name="7002-SORD-011" href="#7002-SORD-011">7002-SORD-011</a>)
-  - **should** have the previous value for the selected market pre-populated (last submitted or last changed) (<a name="7002-SORD-014" href="#7002-SORD-014">7002-SORD-014</a>)
-  - **should** be able to hit up/down on the keyboard to increase the price by the market's tick size (if set, or smallest increment) (<a name="7002-SORD-051" href="#7002-SORD-051">7002-SORD-051</a>)
-    - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows (<a name="7002-SORD-055" href="#7002-SORD-055">7002-SORD-055</a>)
-    - **would like to** be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc. (<a name="7002-SORD-057" href="#7002-SORD-057">7002-SORD-057</a>)
-- **must** be warned (pre-submit) if the input price has too many digits after the decimal place for the market ["quote"](DATA-data_display.md#quote-price) (<a name="7002-SORD-059" href="#7002-SORD-059">7002-SORD-059</a>)
+  - **should** be able quickly pre-populate the price with the current mark price (if there is one, 0 if not) e.g. by focusing the input and hitting up/down
+  - **should** have the previous value for the selected market pre-populated (last submitted or last changed)
+  - **should** be able to hit up/down on the keyboard to increase the price by the market's tick size (if set, or smallest increment)
+    - **should** be able to use modifier keys (SHIFT, ALT etc) to increase/decrease in larger increments with arrows
+    - **would** like to be able to enter a number followed be "k" or "m" or "e2" etc. to make it thousands or millions or hundreds, etc.
+- **must** be warned (pre-submit) if the input price has too many digits after the decimal place for the market ["quote"](7001-DATA-data_display.md#quote-price) (<a name="7002-SORD-059" href="#7002-SORD-059">7002-SORD-059</a>)
 
 ... so that my order only trades at up/down to a particular price
 
@@ -52,7 +84,7 @@ When populating a deal ticket I...
 ... if wanting to trade regardless of price (or assuming that the market is liquid enough that the current best prices are enough of an indication of the price I'll get)...
 
 - **must not** see a price input (<a name="7002-SORD-019" href="#7002-SORD-019">7002-SORD-019</a>)
-- **should** be warning if the market is in auction and the market order may be rejected (<a name="7002-SORD-052" href="#7002-SORD-052">7002-SORD-052</a>)
+- **should** be warning if the market is in auction and the market order may be rejected
 
 ... so I can quickly submit an order without populating the ticket with elements I don't care about
 
@@ -75,10 +107,10 @@ When populating a deal ticket I...
   - Immediate or cancel `IOC` (<a name="7002-SORD-026" href="#7002-SORD-026">7002-SORD-026</a>)
   - Good for normal trading only `GFN` - not applicable to Market orders (<a name="7002-SORD-027" href="#7002-SORD-027">7002-SORD-027</a>)
   - Good for auction only `GFA` - not applicable to Market orders (<a name="7002-SORD-028" href="#7002-SORD-028">7002-SORD-028</a>)
-- **should** only be warned if the time in force is not applicable to the order type I have selected (<a name="7002-SORD-029" href="#7002-SORD-029">7002-SORD-029</a>)
-- **should** only be warned if the time in force is not applicable to current period's trading mode (<a name="7002-SORD-058" href="#7002-SORD-058">7002-SORD-058</a>)
-- if the user has not set a preference: market orders **should** default to `IOC` (<a name="7002-SORD-030" href="#7002-SORD-030">7002-SORD-030</a>)
-- if the user has not set a preference: limit orders **should** default to `GTC` (<a name="7002-SORD-031" href="#7002-SORD-031">7002-SORD-031</a>)
+- **should** only be warned if the time in force is not applicable to the order type I have selected
+- **should** only be warned if the time in force is not applicable to current period's trading mode
+- if the user has not set a preference: market orders **must** default to `IOC` (<a name="7002-SORD-030" href="#7002-SORD-030">7002-SORD-030</a>)
+- if the user has not set a preference: limit orders **must** default to `GTC` (<a name="7002-SORD-031" href="#7002-SORD-031">7002-SORD-031</a>)
 
 ... so I can control if and how my order stays on the order book
 
@@ -93,19 +125,19 @@ When populating a deal ticket I...
 ## See the potential consequences of an order before it is submit
 ... based on the current inputs I'd like an indication of the consequences of my order based on my position and the state of the market, I...
 
-- **could** see my resulting open volume (<a name="7002-SORD-032" href="#7002-SORD-032">7002-SORD-032</a>)
+- **could** see my resulting open volume 
 - **could** see the amount this order might move the market in percentage terms
 - **could** see what the new best prices of the market would be after placing this order (assuming my order moves the market)
-- **could** see new volume weighted average entry price if not 0 (<a name="7002-SORD-033" href="#7002-SORD-033">7002-SORD-033</a>)
+- **could** see new volume weighted average entry price if not 0 
 - **could** see and indication the volume weighted price that this particular order 
 - **could** see an indication of how much of the order will trade when it hits the book and how much might remain passive
-- **could** see a new liquidation level (<a name="7002-SORD-034" href="#7002-SORD-034">7002-SORD-034</a>)
-- **could** see an estimate of the fees that will be paid (if any) (<a name="7002-SORD-035" href="#7002-SORD-035">7002-SORD-035</a>)
+- **could** see a new liquidation level 
+- **could** see an estimate of the fees that will be paid (if any)
 - **could** see my "position leverage" TODO - define this
 - **could** see my "account leverage" TODO - define this 
-- **could** see an amount of realized Profit / Loss (<a name="7002-SORD-036" href="#7002-SORD-036">7002-SORD-036</a>)
-- **could** see any change in margin requirements (if more or less margin will be required) (<a name="7002-SORD-037" href="#7002-SORD-037">7002-SORD-037</a>)
-- **could** see the notional value of my order (<a name="7002-SORD-038" href="#7002-SORD-038">7002-SORD-038</a>)
+- **could** see an amount of realized Profit / Loss 
+- **could** see any change in margin requirements (if more or less margin will be required) 
+- **could** see the notional value of my order 
 
 ... so that I can adjust my inputs before submitting
 
@@ -114,26 +146,27 @@ When populating a deal ticket I...
 ... need to submit my order, when submitting my order, I... 
 
 - if not already connected: **must** see a prompt to [connect a Vega wallet](0002-WCON-connect_vega_wallet.md)
-- **must** submit the [submit order Vega transaction](0003-WTXN-submit_vega_transaction.md). (<a name="7002-SORD-039" href="#7002-SORD-039">7002-SORD-039</a>)
+
+- **must** submit the [Vega submit order transaction](0013-WTXN-submit_vega_transaction.md). (<a name="7002-SORD-039" href="#7002-SORD-039">7002-SORD-039</a>)
 
 - **must** see feedback on my order [status](https://docs.vega.xyz/docs/mainnet/grpc/vega/vega.proto#orderstatus) (not just transaction status above) (<a name="7002-SORD-040" href="#7002-SORD-040">7002-SORD-040</a>)
   - Active (aka Open) (<a name="7002-SORD-041" href="#7002-SORD-041">7002-SORD-041</a>)
   - Expired (<a name="7002-SORD-042" href="#7002-SORD-042">7002-SORD-042</a>)
-  - Cancelled. Should see the txn that cancelled it and a link to the block explorer, if cancelled by a user transaction. (<a name="7002-SORD-043" href="#7002-SORD-043">7002-SORD-043</a>)
-  - Stopped. **should** see an explanation of why stopped (<a name="7002-SORD-044" href="#7002-SORD-044">7002-SORD-044</a>)
-  - Partially filled. **should** see how much of the [size](DATA-data_display.md#size) if filled/remaining (<a name="7002-SORD-045" href="#7002-SORD-045">7002-SORD-045</a>)
+  - Cancelled. see the txn that cancelled it and a link to the block explorer, if cancelled by a user transaction. (<a name="7002-SORD-043" href="#7002-SORD-043">7002-SORD-045</a>)
+  - Stopped. see an explanation of why stopped (<a name="7002-SORD-044" href="#7002-SORD-044">7002-SORD-044</a>)
+  - Partially filled. **must** see how much of the [size](7001-DATA-data_display.md#size) if filled/remaining (<a name="7002-SORD-045" href="#7002-SORD-045">7002-SORD-045</a>)
   - Filled. Must be able to see/link to all trades that were created from this order. (<a name="7002-SORD-046" href="#7002-SORD-046">7002-SORD-046</a>)
   - Rejected: **must** see the reason it was rejected (<a name="7002-SORD-047" href="#7002-SORD-047">7002-SORD-047</a>)
-  - Parked: **should** see an explanation of why parked orders happen (<a name="7002-SORD-048" href="#7002-SORD-048">7002-SORD-048</a>)
+  - Parked: **must** see an explanation of why parked orders happen (<a name="7002-SORD-048" href="#7002-SORD-048">7002-SORD-048</a>)
 - All feedback must be a subscription so is updated as the status changes (<a name="7002-SORD-053" href="#7002-SORD-053">7002-SORD-053</a>)
- - **could** repeat the values that were submitted (order type + all fields) (<a name="7002-SORD-049" href="#7002-SORD-049">7002-SORD-049</a>)
+ - **could** repeat the values that were submitted (order type + all fields)
 
 ... so that I am aware of the status of my order before seeing it in the [orders table](6002-MORD-manage_orders.md).
 
 ... so I get the sort of order, and price, I wish.
 
 ## Manage positions and order
-After submitting orders I'll want to **manage orders** (TODO). If my orders resulted in a position I may wish to **manage positions** (TODO).
+After submitting orders I'll want to [manage orders](7003-MORD-manage_orders.md). If my orders resulted in a position I may wish to [manage positions](7004-POSI-positions.md)).
 
 _____
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -20,7 +20,7 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 ### Fields
 
-- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order
+- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order, because...
   - `Active​`
     - How much of the order is filled / remains unfilled
     - How close the mark price is to my order

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -4,7 +4,7 @@ Users place orders to describe the trades they would like to make: buy or sell, 
 
 Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) in a [list](#orders-list) of other orders. e.g. whether it has been accepted, filled, how close it is to being filled etc. Users may be interested in the price of their orders relative to the price of the market and how much of the order's size has been filled.
 
-Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order cannot be edited on canceled in the same way as other orders.
+Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order cannot be amended on canceled in the same way as other orders.
 
 Markets also have [statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect how a user perceives the state of an order, e.g if the order was placed while in "normal" continuous trading, but the market is now in auction. 
 
@@ -25,7 +25,7 @@ User will have differing needs/preferences in terms of what they want to see abo
     - how much of the order is filled / remains unfilled
     - how close the mark price is to my order
     - if this order is filled at the limit price what would my what effect would it have on realized PnL 
-    - I may want to edit or cancel this order
+    - I may want to amend or cancel this order
   - `Expired​`
     - When did it expire
     - How much was filled / remaining
@@ -61,12 +61,12 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 - **must** see the [time in force](9001-DATA-data_display.md#time-in-force) applied to the order (can be abbreviated here)
 - **should** see created At time stamp. TODO check what happens to this in the context of Pegged and LP orders.
-- **could** see updated at (this is used by the system when an order is edited, or repriced (in pegged and LP) not sure this in needed) TODO check behavior 
+- **could** see updated at (this is used by the system when an order is amended, or repriced (in pegged and LP) not sure this in needed) TODO check behavior 
 
 - **should** see time/order priority (how many orders are before mine at this price)
   
-- if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [Edit/amend](#amend-order---price) the individual order
-- if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to Edit/amend the individual order
+- if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [amend](#amend-order---price) the individual order
+- if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to amend the individual order
   - **could** see a link to amend shape
 - if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [cancel](#cancel-orders) the individual order
 - if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to cancel the individual order
@@ -102,7 +102,7 @@ Read more about [order amends](../protocol/0004-AMND-amends.md).
 
 When looking to amend an order, I...
 
-- **must** be able to edit the price of an order
+- **must** be able to amend the price of an order
   - **could** be warned if the price change will, given the current market, fill the order right away
   - **must** be warned (pre-submit) if the input price has too many digits after the decimal place for the market ["quote"](DATA-data_display.md#quote-price)
 - must submit the Amend order [Vega transaction](0003-WTXN-submit_vega_transaction.md)

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -2,13 +2,11 @@
 
 Users place orders to describe the trades they would like to make: buy or sell, at what price, how long it is valid for etc. In many cases they can edit these orders while they are still active, for example: changing price.
 
+Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) e.g. whether it has been accepted, filled, how close it is to being filled etc. Users may be interested in the price of their orders relative to the price of the market and how much of the order's size has been filled.
+
 Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order cannot be edited on canceled in the same way as other orders.
 
-Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) e.g. whether it has been accepted, filled, how close it is to being filled etc.
-
-Markets also have [statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect how I perceive the state of an order, e.g if the order was placed while in "normal" continuous trading, but the market is now in auction. 
-
-Users may be interested in the price of their orders relative to the price of the market.
+Markets also have [statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect how a user perceives the state of an order, e.g if the order was placed while in "normal" continuous trading, but the market is now in auction. 
 
 ## Orders list
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -84,6 +84,8 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 - **should** be able to sort the list (both directions) by any field in the order list
   - **should** be able to add a secondary sort. e.g. by market then by date  
+- **should** have the default sorted by created time (or updated time if newer), with newest at the top
+- **should** retain sorting preferences between switching views / browser reload
 
 ### Grouping
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -51,8 +51,8 @@ User will have differing needs/preferences in terms of what they want to see abo
   - **could** see what part of the liquidity shape or pegged order shape this relates to. See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
   - **could** see link to my full shape
 
-- **should** see how much has been filled [size](9001-DATA-data_display.md#size) e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
-- **should** see how much of the orders [size](9001-DATA-data_display.md#size) remains. Note: this does not go to zero if the order status goes to a closed state. TODO double check what the API does in a situation where I got 50% fill then canceled an order 
+- **should** see how much of the order's [size](9001-DATA-data_display.md#size) has been filled e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
+- **should** see how much of the order's [size](9001-DATA-data_display.md#size) remains. Note: this does not go to zero if the order status goes to a closed state. TODO double check what the API does in a situation where I got 50% fill then canceled an order 
 
 - if order type = `Limit`: **must** see the Limit [price](9001-DATA-data_display.md#quote-price) that was set on the order
 - if order type = `Market`: **must** not see a price for active or parked orders, a `-`, `Market` or `n/a` is more appropriate (API may return 0).

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -72,6 +72,8 @@ User will have differing needs/preferences in terms of what they want to see abo
 - if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to cancel the individual order
   - **could** see a link to cancel shape
 
+- `todo` show the reference and offset for an order for liquidity and pegged orders (instead of price?)
+
 ### Filters
 
 - **should** have the ability to see all orders regardless of status in one list

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -1,9 +1,9 @@
 # Manage orders
 
-Users place orders to describe the trades they would like to make, buy/sell, price, and how long the bid/ask is valid for etc. In many cases they can edit these orders, changing price etc.
-Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order can not be edited on canceled in the same way as other orders.
+Users place orders to describe the trades they would like to make: buy or sell, at what price, how long it is valid for etc. In many cases they can edit these orders while they are still active, for example: changing price.
+Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order cannot be edited on canceled in the same way as other orders.
 Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) e.g. whether it has been accepted, filled, how close it is to being filled etc.
-Markets also have [statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect what can be done with an order, e.g if the order was placed while in "normal" continuous trading, but the market is now in auction. 
+Markets also have [statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect how I perceive the state of an order, e.g if the order was placed while in "normal" continuous trading, but the market is now in auction. 
 Users may be interested in the price of their orders relative to the price of the market.
 
 ## Orders list
@@ -12,8 +12,8 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 ### Field customization
 
-- **should** have the ability to select what [fields/data](#fields) is shown for each order in the list
-- **should** have the ability to change the order of items in the list
+- **should** have the ability to select what [fields/data](#fields) are shown for each order in the list
+- **should** have the ability to change the order of fields (e.g. table columns)
 - **should** have the ability to give each column in the list more or less space
 
 ### Fields
@@ -21,25 +21,26 @@ User will have differing needs/preferences in terms of what they want to see abo
 - **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order
   - `Active​`
     - how much of the order is filled / remains unfilled
-    - how close the mark price is my order
+    - how close the mark price is to my order
     - if this order is filled at the limit price what would my what effect would it have on realized PnL 
     - I may want to edit or cancel this order
   - `Expired​`
     - When did it expire
     - How much was filled / remaining
   - `Cancelled​`
-    - What canceled it? This generally means that it was canceled by the user but there may be exceptions (TODO Documentation needed)  
+    - What canceled it? When did I cancel it TODO double check that "cancelled" only comes from user action 
   - `Stopped​`
-    - What stopped it (e.g. was it because an [FOC](9001-DATA-data_display.md#time-in-force) that was not filled)
+    - What stopped it (e.g. was it because an [FOC](9001-DATA-data_display.md#time-in-force) that was not filled, or because of margin availability)
   - `Filled​`
     - What was the average fill price I got for this order
   - `Rejected​`
-    - Why was this order rejected
+    - Why was this order rejected (show `rejectedReason`)
   - `PartiallyFilled​`
-    - how much was filled before the order was canceled)
+    - how much was filled before the order was canceled
     - what was the average fill price I got for this order
   - `Parked​`
-    - Why is the market currently in auction TODO find out what happens to the limit orders in the orders API when market is in auction
+    - Why is the market currently in auction
+    - link to pegged shape (see bellow) TODO find out what happens to the limit orders in the orders API when market is in auction
 
 - **must** see what [market](9001-DATA-data_display.md#market) an order is related to (either code, ID or name, preferable name)
   - **should** see what the status is of the market (particularly if it is not "normal")

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -1,1 +1,95 @@
 # Manage orders
+User place orders as a way of expressing the trades they would like to make. 
+Once a user has placed an order they may wish to confirm its state e.g. whether it has been filled or not.
+They may also wish to make amendments to that order.
+
+Orders have different [Order statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status). These statuses have consequences on the way you can manage an order.
+
+Markets also have statuses [market statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state)
+These also have consequences on what you can do with an order
+- parked pegged orders
+- editing orders during auction?
+  Generally when looking at an order a user will want to know what status the market it is in particularly if the market is not in it's "normal" trading mode.
+
+Orders are typically the result of placing a limit, stop, market order etc, But some order will be there as the result of placing a pegged order or liquidity order shape which is an instruction to the network to place limit orders on your behalf and move them when market prices change.
+
+## Open (aka active) orders
+When reviewing the orders I have placed and their status, I...
+
+Customization
+- **should** have the ability to view all data that is available on a given order or view of orders
+
+Filters
+- **should** have the ability to see all orders (active and non-active))
+- should have the ability to see only active + Parked orders TODO update this based on what happens to parked orders
+- should hte ability to see only non-active + Parked orders (i.e. all orders that do not have the status of )
+- should have the ability to see only 
+
+Sorting TODO
+
+Grouping TODO
+
+
+
+- **must** see [Status](TODO-Do-we-need-this?) of the order
+
+- Depending on the order, I...
+  - Active​ - Remaining, how close the market is my order, (I may want to edit or cancel this order)
+  - Expired​ - when did it expire, how much was filled remaining
+  - Cancelled​ - What canceled it. This generally means that it was canceled by the user but there may be exceptions (TODO Documentation needed)  
+  - Stopped​ - What stopped it (e.g. was it because an [FOC](9001-DATA-data_display.md#time-in-force) that was not filled)
+  - Filled​ - What was the fill price I got for this order
+  - Rejected​ - Why was this order rejected
+  - PartiallyFilled​ - how much was filled before the order was canceled)
+  - Parked​ - Why is the market currently in auction TODO find out what happens to the limit orders in the orders API when market is in auction
+
+For each order:
+- **must** see what [market](9001-DATA-data_display.md#market) an order is related to (either code, ID or name, preferable name)
+  - **should** see what the status is of the market (particularly if it is not "normal")
+- **must** see the [Size](9001-DATA-data_display.md#size) of the order
+- **must** see the [direction](9001-DATA-data_display.md#direction--side) (Long or Short) of the order (this can be implied with a + or negative suffix on the size, + for Long, - for short)
+- **must** see [Order type](9001-DATA-data_display.md#order-type)
+- **should** see order origin (pegged and liquidity orders)
+  - if origin is [pegged or liquidity provision shape](9001-DATA-data_display.md#order-origin): order **could** see what part of the liquidity shape or pegged order shape this relates to. See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
+
+- **should** see how much has been Filled [size](9001-DATA-data_display.md#size) e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
+- **should** see how much of the orders [size](9001-DATA-data_display.md#size) remains. Note: this does not go to zero if the order status goes to a closed state. TODO double check what the API does in a situation where I got 50% fill then canceled an order 
+
+- if order type = `Limit`: **must** see the Limit [price](9001-DATA-data_display.md#quote-price) that was set on the order
+- if order type = `Market`: **must** not see a price for active or parked orders, a `-`, `Market` or `n/a` is more appropriate (API may return 0). 
+
+- **must** see the [time in force](9001-DATA-data_display.md#time-in-force) applied to the order (can be abbreviated here)
+- **should** see Created At time stamp. TODO check what happens to this in the context of Pegged and LP orders.
+- **could** see Updated at (this is used by the system when an order is edited, or repriced (in pegged and LP) not sure this in needed) TODO check behavior 
+  
+- if the order is `Active` or `Parked`: **must** see an option to [Edit/amend](#amend-orders) the individual order
+  - if order origin is pegged or Liquidity: 
+    - **must** not see edit a [pegged or liquidity shape](9001-DATA-data_display.md#order-origin)
+    - **should** see ability to edit [liquidity](#liquidity-order-shapes) or [peg](#pegged-order-shapes) shape below
+- if the order is `Active` or `Parked`: **must** see an option to [Cancel](#cancel-orders) the individual order
+
+... so I can decide what I want to do (if anything) and find the actions to do it.
+## Cancel orders
+
+- **must** see ability to cancel the order
+- submit the cancel transaction
+- see feedback on the transaction
+## Amend orders
+
+- **must** be able to edit the price of an order
+- if the market status make the editing not possible TBD (e.g. edit order while in auction) TODO check what needs to be done
+- if the type of change is not possible
+- Other amends to an order TBD
+
+- must submit or cancel the order
+- must see the status of the order once confirmed on block
+
+## On a chart
+
+TBD
+## Pegged order shapes
+
+TBD
+## Liquidity order shapes
+
+TBD

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -20,7 +20,9 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 ### Fields
 
-- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order, and therefore... (<a name="7003-MORD-001" href="#7003-MORD-001">7003-MORD-001</a>)
+When looking at a list of orders, I...
+
+- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order (<a name="7003-MORD-001" href="#7003-MORD-001">7003-MORD-001</a>), and therefore (nested bullets added for context, ACs are on fields that follow)... 
   - `Active​`
     - How much of the order is filled / remains unfilled
     - How close the mark price is to order
@@ -45,23 +47,23 @@ User will have differing needs/preferences in terms of what they want to see abo
     - Link to pegged shape (see bellow) TODO find out what happens to the limit orders in the orders API when market is in auction
 
 - **must** see what [market](9001-DATA-data_display.md#market) an order is related to (either code, ID or name, preferable name) (<a name="7003-MORD-002" href="#7003-MORD-002">7003-MORD-002</a>)
-  - **should** see what the status is of the market (particularly if it is not "normal")
+  - **should** see what the `status` is of the market (particularly if it is not "normal")
 - **must** see the [size](9001-DATA-data_display.md#size) of the order (<a name="7003-MORD-003" href="#7003-MORD-003">7003-MORD-003</a>)
 - **must** see the [direction/side](9001-DATA-data_display.md#direction--side) (Long or Short) of the order (this can be implied with a + or negative suffix on the size, + for Long, - for short) (<a name="7003-MORD-004" href="#7003-MORD-004">7003-MORD-004</a>)
 - **must** see [order type](9001-DATA-data_display.md#order-type) (<a name="7003-MORD-005" href="#7003-MORD-005">7003-MORD-005</a>)
 - if order created by [pegged or liquidity provision shape](9001-DATA-data_display.md#order-origin): **should** see order origin
-  - **could** see what part of the liquidity shape or pegged order shape this relates to. See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
+  - **could** see what part of the liquidity shape or pegged order shape this relates to or it's offset+reference See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
   - **could** see link to full shape
 
 - **should** see how much of the order's [size](9001-DATA-data_display.md#size) has been filled e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
-- **should** see how much of the order's [size](9001-DATA-data_display.md#size) remains. Note: this does not go to zero if the order status goes to a closed state. TODO double check what the API does in a situation where I got 50% fill then canceled an order 
+- **should** see how much of the order's [size](9001-DATA-data_display.md#size) remains. 
 
 - if order type = `Limit`: **must** see the Limit [price](9001-DATA-data_display.md#quote-price) that was set on the order
 - if order type = `Market`: **must** not see a price for active or parked orders, a `-`, `Market` or `n/a` is more appropriate (API may return `0`).
 
 - **must** see the [time in force](9001-DATA-data_display.md#time-in-force) applied to the order (can be abbreviated here) (<a name="7003-MORD-006" href="#7003-MORD-006">7003-MORD-006</a>)
-- **should** see "created at" [time](9001-DATA-data_display.md#time). TODO check what happens to this in the context of Pegged and LP orders.
-- **could** see updated at (this is used by the system when an order is amended, or repriced (in pegged and LP) not sure this in needed) TODO check behavior 
+- **should** see "created at" [time](9001-DATA-data_display.md#time)
+- **could** see updated at (this is used by the system when an order is amended, or repriced (in pegged and LP) not sure this in needed)
 
 - **should** see time priority (how many orders are before mine at this price)
   
@@ -72,9 +74,10 @@ User will have differing needs/preferences in terms of what they want to see abo
 - if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to cancel the individual order
   - **could** see a link to cancel shape
 
-- `todo` show the reference and offset for an order for liquidity and pegged orders (instead of price?)
-
+... so I can understand the state of my orders and decide what to do next
 ### Filters
+
+When looking at a list of orders, I...
 
 - **should** have the ability to see all orders regardless of status in one list
 - **should** have the ability to see only active &amp; parked orders TODO update this based on what happens to parked orders
@@ -82,25 +85,36 @@ User will have differing needs/preferences in terms of what they want to see abo
 - **could** have the ability to filter by any field(s)
   - where a field is an enum: **should** be able to select one on or more values for a field that should be included
 
+... so I can focus on the type of orders statuses etc that I want to at that time
+
 ### Sorting
+
+When looking at a list of orders, I...
 
 - **should** be able to sort the list (both directions) by any field in the order list
   - **should** be able to add a secondary sort. e.g. by market then by date  
 - **should** have the default sorted by created time (or updated time if newer), with newest at the top
 - **should** retain sorting preferences between switching views / browser reload
 
+... so the sort order matches my mental model and or makes it easy for me to find the orders I am looking for  
 ### Grouping
+
+When looking at a list of orders, I...
 
 - **should** be able to group orders by any field e.g. by market, lp etc
 - **should** have default grouping by market
 
+... so I can make decisions easily on a set of orders 
 ## Cancel orders
+
+When looking to take order out of the book, I...
 
 - **must** select weather to cancel an individual order or all orders on a market (<a name="7003-MORD-009" href="#7003-MORD-009">7003-MORD-009</a>)
 - **must** be able to submit the [Vega transaction](0003-WTXN-submit_vega_transaction.md) to cancel order(s) (<a name="7003-MORD-010" href="#7003-MORD-010">7003-MORD-010</a>)
   - **could** show the margin requirement reduction/increase that will take place before submitting
-- **must** see feedback on order status after the transaction (<a name="7003-MORD-011" href="#7003-MORD-011">7003-MORD-011</a>)
+- **must** see feedback on order status after the [Vega transaction](0003-WTXN-submit_vega_transaction.md) (<a name="7003-MORD-011" href="#7003-MORD-011">7003-MORD-011</a>)
 
+... so that the order will not be filled and I don't end up with a change in my position that I was not expecting
 ## Amend order - price
 
 Read more about [order amends](../protocol/0004-AMND-amends.md).
@@ -117,7 +131,7 @@ When looking to amend an order, I...
 
 ## Amend order - other than price
 
-`TBD` -  Acceptance criteria for other types of order amend 
+`TODO` -  Acceptance criteria for other types of order amend 
 
 ## On a price history chart
 
@@ -157,7 +171,12 @@ When looking to understand the state of a pegged order shape...
 - **would** like to see link to edit the shape of a pegged order
 - **would** like to see the date submitted/updated
 
-... so I can decide if I wish to amend or cancel my order
+... so I can decide if I wish to amend or cancel my pegged order shape
+
+## Cancel Pegged order shapes
+
+`TODO`
+
 ## Liquidity order shapes
 
 When looking to understand the state of a liquidity provision, with a provided shape... 
@@ -174,3 +193,7 @@ When looking to understand the state of a liquidity provision, with a provided s
 - **would** like to see the date submitted/updated
 
 ... so I can decide if I wish to amend or cancel my shape
+
+## Cancel or amend Pegged order shapes
+
+See [liquidity provision](5002-LIQP-provide_liquidity.md),

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -1,97 +1,160 @@
 # Manage orders
-User place orders to describe the trades they would like to make, e.g. what buy/sell, price, and how long the bid/ask is valid for.
+
+Users place orders to describe the trades they would like to make, buy/sell, price, and how long the bid/ask is valid for etc. In many cases they can edit these orders, changing price etc.
 Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order can not be edited on canceled in the same way as other orders.
-Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) e.g. whether it has been accepted, filled or not.
-They may also wish to make amendment or cancel an order based on the state of the market. The status of an order implies wether it can be edited or canceled.
-Markets also have statuses [market statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect what can be done with an order, or what a user might want to do with it e.g if the order was placed while in "normal" continuous trading, but the market is now in auction.
+Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) e.g. whether it has been accepted, filled, how close it is to being filled etc.
+Markets also have [statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect what can be done with an order, e.g if the order was placed while in "normal" continuous trading, but the market is now in auction. 
+Users may be interested in the price of their orders relative to the price of the market.
 
-## View Orders
+## Orders list
 
-User will have differing needs/preferences in terms of what they see about an order and how these orders are grouped listed. It is common for interfaces to allow users to customize how orders are displayed.
+User will have differing needs/preferences in terms of what they want to see about an order and how orders are grouped and listed. It is common for interfaces to allow users to customize how orders are displayed.
 
-Customization
+### Field customization
 
-- **should** have the ability to select what data is shown for each order in the list
+- **should** have the ability to select what [fields/data](#fields) is shown for each order in the list
 - **should** have the ability to change the order of items in the list
 - **should** have the ability to give each column in the list more or less space
 
-Filters
+### Fields
 
-- **should** have the ability to see all orders (active and non-active))
-- **should** have the ability to see only active + Parked orders TODO update this based on what happens to parked orders
-- **should** hte ability to see only non-active + Parked orders (i.e. all orders that do not have the status of )
-- **could** have the ability to filter by any field(s)
-  - where a field is an enum: **should** be able to select one on or more values for a field that should be included
+- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order
+  - `Active​`
+    - how much of the order is filled / remains unfilled
+    - how close the mark price is my order
+    - if this order is filled at the limit price what would my what effect would it have on realized PnL 
+    - I may want to edit or cancel this order
+  - `Expired​`
+    - When did it expire
+    - How much was filled / remaining
+  - `Cancelled​`
+    - What canceled it? This generally means that it was canceled by the user but there may be exceptions (TODO Documentation needed)  
+  - `Stopped​`
+    - What stopped it (e.g. was it because an [FOC](9001-DATA-data_display.md#time-in-force) that was not filled)
+  - `Filled​`
+    - What was the average fill price I got for this order
+  - `Rejected​`
+    - Why was this order rejected
+  - `PartiallyFilled​`
+    - how much was filled before the order was canceled)
+    - what was the average fill price I got for this order
+  - `Parked​`
+    - Why is the market currently in auction TODO find out what happens to the limit orders in the orders API when market is in auction
 
-Sorting
-
-- **should** be able to sort the list (both directions) by any field in the order list
-  - **should** be able to add a secondry sort. e.g. by market then by date  
-
-Grouping 
-- **should** be able to group by any field e.g. by market
-
-However, in a general case: When reviewing the orders I have placed and their status, I...
-
-- **must** see [Status](TODO-Do-we-need-this?) of the order
-
-- Depending on the order, I...
-  - Active​ - Remaining, how close the market is my order, (I may want to edit or cancel this order)
-  - Expired​ - when did it expire, how much was filled remaining
-  - Cancelled​ - What canceled it. This generally means that it was canceled by the user but there may be exceptions (TODO Documentation needed)  
-  - Stopped​ - What stopped it (e.g. was it because an [FOC](9001-DATA-data_display.md#time-in-force) that was not filled)
-  - Filled​ - What was the fill price I got for this order
-  - Rejected​ - Why was this order rejected
-  - PartiallyFilled​ - how much was filled before the order was canceled)
-  - Parked​ - Why is the market currently in auction TODO find out what happens to the limit orders in the orders API when market is in auction
-
-For each order:
 - **must** see what [market](9001-DATA-data_display.md#market) an order is related to (either code, ID or name, preferable name)
   - **should** see what the status is of the market (particularly if it is not "normal")
-- **must** see the [Size](9001-DATA-data_display.md#size) of the order
-- **must** see the [direction](9001-DATA-data_display.md#direction--side) (Long or Short) of the order (this can be implied with a + or negative suffix on the size, + for Long, - for short)
-- **must** see [Order type](9001-DATA-data_display.md#order-type)
-- **should** see order origin (pegged and liquidity orders)
-  - if origin is [pegged or liquidity provision shape](9001-DATA-data_display.md#order-origin): order **could** see what part of the liquidity shape or pegged order shape this relates to. See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
+- **must** see the [size](9001-DATA-data_display.md#size) of the order
+- **must** see the [direction/side](9001-DATA-data_display.md#direction--side) (Long or Short) of the order (this can be implied with a + or negative suffix on the size, + for Long, - for short)
+- **must** see [order type](9001-DATA-data_display.md#order-type)
+- if order created by [pegged or liquidity provision shape](9001-DATA-data_display.md#order-origin): **should** see order origin
+  - **could** see what part of the liquidity shape or pegged order shape this relates to. See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
+  - **could** see link to my full shape
 
-- **should** see how much has been Filled [size](9001-DATA-data_display.md#size) e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
+- **should** see how much has been filled [size](9001-DATA-data_display.md#size) e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
 - **should** see how much of the orders [size](9001-DATA-data_display.md#size) remains. Note: this does not go to zero if the order status goes to a closed state. TODO double check what the API does in a situation where I got 50% fill then canceled an order 
 
 - if order type = `Limit`: **must** see the Limit [price](9001-DATA-data_display.md#quote-price) that was set on the order
-- if order type = `Market`: **must** not see a price for active or parked orders, a `-`, `Market` or `n/a` is more appropriate (API may return 0). 
+- if order type = `Market`: **must** not see a price for active or parked orders, a `-`, `Market` or `n/a` is more appropriate (API may return 0).
 
 - **must** see the [time in force](9001-DATA-data_display.md#time-in-force) applied to the order (can be abbreviated here)
-- **should** see Created At time stamp. TODO check what happens to this in the context of Pegged and LP orders.
-- **could** see Updated at (this is used by the system when an order is edited, or repriced (in pegged and LP) not sure this in needed) TODO check behavior 
-  
-- if the order is `Active` or `Parked`: **must** see an option to [Edit/amend](#amend-orders) the individual order
-  - if order origin is pegged or Liquidity: 
-    - **must** not see edit a [pegged or liquidity shape](9001-DATA-data_display.md#order-origin)
-    - **should** see ability to edit [liquidity](#liquidity-order-shapes) or [peg](#pegged-order-shapes) shape below
-- if the order is `Active` or `Parked`: **must** see an option to [Cancel](#cancel-orders) the individual order
+- **should** see created At time stamp. TODO check what happens to this in the context of Pegged and LP orders.
+- **could** see updated at (this is used by the system when an order is edited, or repriced (in pegged and LP) not sure this in needed) TODO check behavior 
 
-... so I can decide what I want to do (if anything) and find the actions to do it.
+- **should** see time/order priority (how many orders are before mine at this price)
+  
+- if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [Edit/amend](#amend-order---price) the individual order
+- if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to Edit/amend the individual order
+  - **could** see a link to amend shape
+- if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [cancel](#cancel-orders) the individual order
+- if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to cancel the individual order
+  - **could** see a link to cancel shape
+
+### Filters
+
+- **should** have the ability to see all orders regardless of status in one list
+- **should** have the ability to see only active &amp; parked orders TODO update this based on what happens to parked orders
+- **should** have the ability to see only non-active &amp; parked order (i.e. all orders that do not have the status of Active &amp; Parked)
+- **could** have the ability to filter by any field(s)
+  - where a field is an enum: **should** be able to select one on or more values for a field that should be included
+
+### Sorting
+
+- **should** be able to sort the list (both directions) by any field in the order list
+  - **should** be able to add a secondary sort. e.g. by market then by date  
+
+### Grouping
+
+- **should** be able to group orders by any field e.g. by market, lp etc
+
 ## Cancel orders
 
-- **must** see ability to cancel the order
-- submit the cancel transaction
-- see feedback on the transaction
-## Amend orders
+- **must** select weather to cancel an individual order or all orders on a market
+- **must** be able to submit the [Vega transaction](0003-WTXN-submit_vega_transaction.md) to cancel order(s)
+  - **could** show the margin requirement reduction/increase that will take place before submitting
+- **must** see feedback on my order status after the transaction
+
+## Amend order - price
+
+Read more about [order amends](../protocol/0004-AMND-amends.md).
+
+When looking to amend an order, I...
 
 - **must** be able to edit the price of an order
-- if the market status make the editing not possible TBD (e.g. edit order while in auction) TODO check what needs to be done
-- if the type of change is not possible
-- Other amends to an order TBD
+  - **could** be warned if the price change will, given the current market, fill the order right away
+  - **must** be warned (pre-submit) if the input price has too many digits after the decimal place for the market ["quote"](DATA-data_display.md#quote-price)
+- must submit the Amend order [Vega transaction](0003-WTXN-submit_vega_transaction.md)
+- must see the status after the transaction (see [submit order](7002-SORD-submit_orders.md#submit-an-order))
 
-- must submit or cancel the order
-- must see the status of the order once confirmed on block
+... so the order is more likely to get filled or will be filled at a more competitive price
 
-## On a chart
+## Amend order - other types
 
-TBD
+`TBD` -  Acceptance criteria for other types of order amend 
+## On a price history chart
+
+when looking at a price history chart, I...
+
+- **would** like to see all my active orders shown on the vertical axis
+- **would** like to drag orders to change their price
+
+... so I can see my orders in context of price history
+## On a depth chart
+
+when looking at a depth chart, I...
+
+- **would** like to see all my active orders shown on the horizontal axis
+- **would** like to drag orders to change their price
+
+... so I can see my orders in context of price history
+
+## In order book
+
+when looking at an order book, I...
+
+- **would** like to see all my active orders shown next to the prices they have
+
+... so I can see my orders in context of price history
+
 ## Pegged order shapes
 
-TBD
+When looking to understand the state of a pegged order shape...
+
+- **would** like to see the pegged order status (e.g. active, parked, canceled etc)
+- **would** like to see the shape I submitted
+  - **would** like to see each buy/sell order with it's reference and offset
+  - **would** like to see the current price for each buy/sell
+- **would** like to see what parts of this shape have been filled and what remains
+
+... so I can decide if I wish to amend or cancel my order
 ## Liquidity order shapes
 
-TBD
+When looking to understand the state of a liquidity provision... 
+
+- **would** like to see the liquidity commitment order status (e.g. pending, active, parked, canceled etc)
+- **would** like to see the shape I submitted
+  - **would** like to see each buy/sell order with it's reference and offset
+  - **would** like to see the current price for each buy/sell
+- **would** like to see the fee bid
+- **would** like to see the date submitted/updated
+
+... so I can decide if I wish to amend or cancel my shape

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -1,35 +1,37 @@
 # Manage orders
-User place orders as a way of expressing the trades they would like to make. 
-Once a user has placed an order they may wish to confirm its state e.g. whether it has been filled or not.
-They may also wish to make amendments to that order.
+User place orders to describe the trades they would like to make, e.g. what buy/sell, price, and how long the bid/ask is valid for.
+Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order can not be edited on canceled in the same way as other orders.
+Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) e.g. whether it has been accepted, filled or not.
+They may also wish to make amendment or cancel an order based on the state of the market. The status of an order implies wether it can be edited or canceled.
+Markets also have statuses [market statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect what can be done with an order, or what a user might want to do with it e.g if the order was placed while in "normal" continuous trading, but the market is now in auction.
 
-Orders have different [Order statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status). These statuses have consequences on the way you can manage an order.
+## View Orders
 
-Markets also have statuses [market statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state)
-These also have consequences on what you can do with an order
-- parked pegged orders
-- editing orders during auction?
-  Generally when looking at an order a user will want to know what status the market it is in particularly if the market is not in it's "normal" trading mode.
-
-Orders are typically the result of placing a limit, stop, market order etc, But some order will be there as the result of placing a pegged order or liquidity order shape which is an instruction to the network to place limit orders on your behalf and move them when market prices change.
-
-## Open (aka active) orders
-When reviewing the orders I have placed and their status, I...
+User will have differing needs/preferences in terms of what they see about an order and how these orders are grouped listed. It is common for interfaces to allow users to customize how orders are displayed.
 
 Customization
-- **should** have the ability to view all data that is available on a given order or view of orders
+
+- **should** have the ability to select what data is shown for each order in the list
+- **should** have the ability to change the order of items in the list
+- **should** have the ability to give each column in the list more or less space
 
 Filters
+
 - **should** have the ability to see all orders (active and non-active))
-- should have the ability to see only active + Parked orders TODO update this based on what happens to parked orders
-- should hte ability to see only non-active + Parked orders (i.e. all orders that do not have the status of )
-- should have the ability to see only 
+- **should** have the ability to see only active + Parked orders TODO update this based on what happens to parked orders
+- **should** hte ability to see only non-active + Parked orders (i.e. all orders that do not have the status of )
+- **could** have the ability to filter by any field(s)
+  - where a field is an enum: **should** be able to select one on or more values for a field that should be included
 
-Sorting TODO
+Sorting
 
-Grouping TODO
+- **should** be able to sort the list (both directions) by any field in the order list
+  - **should** be able to add a secondry sort. e.g. by market then by date  
 
+Grouping 
+- **should** be able to group by any field e.g. by market
 
+However, in a general case: When reviewing the orders I have placed and their status, I...
 
 - **must** see [Status](TODO-Do-we-need-this?) of the order
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -20,7 +20,7 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 ### Fields
 
-- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order, because...
+- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order, because... (<a name="7003-MORD-001" href="#7003-MORD-001">7003-MORD-001</a>)
   - `Active​`
     - How much of the order is filled / remains unfilled
     - How close the mark price is to order
@@ -44,11 +44,11 @@ User will have differing needs/preferences in terms of what they want to see abo
     - Why is the market currently in auction
     - Link to pegged shape (see bellow) TODO find out what happens to the limit orders in the orders API when market is in auction
 
-- **must** see what [market](9001-DATA-data_display.md#market) an order is related to (either code, ID or name, preferable name)
+- **must** see what [market](9001-DATA-data_display.md#market) an order is related to (either code, ID or name, preferable name) (<a name="7003-MORD-002" href="#7003-MORD-002">7003-MORD-002</a>)
   - **should** see what the status is of the market (particularly if it is not "normal")
-- **must** see the [size](9001-DATA-data_display.md#size) of the order
-- **must** see the [direction/side](9001-DATA-data_display.md#direction--side) (Long or Short) of the order (this can be implied with a + or negative suffix on the size, + for Long, - for short)
-- **must** see [order type](9001-DATA-data_display.md#order-type)
+- **must** see the [size](9001-DATA-data_display.md#size) of the order (<a name="7003-MORD-003" href="#7003-MORD-003">7003-MORD-003</a>)
+- **must** see the [direction/side](9001-DATA-data_display.md#direction--side) (Long or Short) of the order (this can be implied with a + or negative suffix on the size, + for Long, - for short) (<a name="7003-MORD-004" href="#7003-MORD-004">7003-MORD-004</a>)
+- **must** see [order type](9001-DATA-data_display.md#order-type) (<a name="7003-MORD-005" href="#7003-MORD-005">7003-MORD-005</a>)
 - if order created by [pegged or liquidity provision shape](9001-DATA-data_display.md#order-origin): **should** see order origin
   - **could** see what part of the liquidity shape or pegged order shape this relates to. See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
   - **could** see link to full shape
@@ -59,14 +59,14 @@ User will have differing needs/preferences in terms of what they want to see abo
 - if order type = `Limit`: **must** see the Limit [price](9001-DATA-data_display.md#quote-price) that was set on the order
 - if order type = `Market`: **must** not see a price for active or parked orders, a `-`, `Market` or `n/a` is more appropriate (API may return `0`).
 
-- **must** see the [time in force](9001-DATA-data_display.md#time-in-force) applied to the order (can be abbreviated here)
+- **must** see the [time in force](9001-DATA-data_display.md#time-in-force) applied to the order (can be abbreviated here) (<a name="7003-MORD-006" href="#7003-MORD-006">7003-MORD-006</a>)
 - **should** see "created at" [time](9001-DATA-data_display.md#time). TODO check what happens to this in the context of Pegged and LP orders.
 - **could** see updated at (this is used by the system when an order is amended, or repriced (in pegged and LP) not sure this in needed) TODO check behavior 
 
 - **should** see time priority (how many orders are before mine at this price)
   
-- if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [amend](#amend-order---price) the individual order
-- if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to amend the individual order
+- if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [amend](#amend-order---price) the individual order (<a name="7003-MORD-007" href="#7003-MORD-007">7003-MORD-007</a>)
+- if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to amend the individual order (<a name="7003-MORD-008" href="#7003-MORD-008">7003-MORD-008</a>)
   - **could** see a link to amend shape
 - if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [cancel](#cancel-orders) the individual order
 - if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to cancel the individual order
@@ -94,10 +94,10 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 ## Cancel orders
 
-- **must** select weather to cancel an individual order or all orders on a market
-- **must** be able to submit the [Vega transaction](0003-WTXN-submit_vega_transaction.md) to cancel order(s)
+- **must** select weather to cancel an individual order or all orders on a market (<a name="7003-MORD-009" href="#7003-MORD-009">7003-MORD-009</a>)
+- **must** be able to submit the [Vega transaction](0003-WTXN-submit_vega_transaction.md) to cancel order(s) (<a name="7003-MORD-010" href="#7003-MORD-010">7003-MORD-010</a>)
   - **could** show the margin requirement reduction/increase that will take place before submitting
-- **must** see feedback on order status after the transaction
+- **must** see feedback on order status after the transaction (<a name="7003-MORD-011" href="#7003-MORD-011">7003-MORD-011</a>)
 
 ## Amend order - price
 
@@ -105,11 +105,11 @@ Read more about [order amends](../protocol/0004-AMND-amends.md).
 
 When looking to amend an order, I...
 
-- **must** be able to amend the price of an order
+- **must** be able to amend the price of an order (<a name="7003-MORD-012" href="#7003-MORD-012">7003-MORD-012</a>)
   - **could** be warned if the price change will, given the current market, fill the order right away
-  - **must** be warned (pre-submit) if the input price has too many digits after the decimal place for the market ["quote"](DATA-data_display.md#quote-price)
-- must submit the Amend order [Vega transaction](0003-WTXN-submit_vega_transaction.md)
-- must see the status after the transaction (see [submit order](7002-SORD-submit_orders.md#submit-an-order))
+  - **must** be warned (pre-submit) if the input price has too many digits after the decimal place for the market ["quote"](DATA-data_display.md#quote-price) (<a name="7003-MORD-013" href="#7003-MORD-013">7003-MORD-013</a>)
+- **must** submit the Amend order [Vega transaction](0003-WTXN-submit_vega_transaction.md) (<a name="7003-MORD-014" href="#7003-MORD-014">7003-MORD-014</a>)
+- **must** see the status after the transaction (see [submit order](7002-SORD-submit_orders.md#submit-an-order)) (<a name="7003-MORD-015" href="#7003-MORD-015">7003-MORD-015</a>)
 
 ... so the order is more likely to get filled or will be filled at a more competitive price
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -1,8 +1,8 @@
 # Manage orders
 
-Users place orders to describe the trades they would like to make: buy or sell, at what price, how long it is valid for etc. In many cases they can edit these orders while they are still active, for example: changing price.
+Users place orders to describe the trades they would like to make: buy or sell, at what price, how long it is valid for etc. In many cases they can [ammend](#amend-order---price) or [cancel](#cancel-orders) these orders while they are still active, for example: changing price.
 
-Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) e.g. whether it has been accepted, filled, how close it is to being filled etc. Users may be interested in the price of their orders relative to the price of the market and how much of the order's size has been filled.
+Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) in a [list](#orders-list) of other orders. e.g. whether it has been accepted, filled, how close it is to being filled etc. Users may be interested in the price of their orders relative to the price of the market and how much of the order's size has been filled.
 
 Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order cannot be edited on canceled in the same way as other orders.
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -115,9 +115,10 @@ When looking to amend an order, I...
 
 ... so the order is more likely to get filled or will be filled at a more competitive price
 
-## Amend order - other types
+## Amend order - other than price
 
 `TBD` -  Acceptance criteria for other types of order amend 
+
 ## On a price history chart
 
 when looking at a price history chart, I...
@@ -147,22 +148,29 @@ when looking at an order book, I...
 
 When looking to understand the state of a pegged order shape...
 
-- **would** like to see the pegged order status (e.g. active, parked, canceled etc)
-- **would** like to see the shape I submitted
-  - **would** like to see each buy/sell order with it's reference and offset
-  - **would** like to see the current price for each buy/sell
-- **would** like to see what parts of this shape have been filled and what remains
+- **should** see the whole shape of a pegged order
+- **must** see the reference and offset for each part pegged order (<a name="7003-MORD-016" href="#7003-MORD-016">7003-MORD-016</a>)
+- **should** see the current price for each buy/sell
+- **should** see the filled/remaining for each part of the order
+- when order is not `Active`: **should** show the order status (perhaps instead of price)
+- **should** be able to cancel the whole pegged order
+- **would** like to see link to edit the shape of a pegged order
+- **would** like to see the date submitted/updated
 
 ... so I can decide if I wish to amend or cancel my order
 ## Liquidity order shapes
 
-When looking to understand the state of a liquidity provision... 
+When looking to understand the state of a liquidity provision, with a provided shape... 
 
-- **would** like to see the liquidity commitment order status (e.g. pending, active, parked, canceled etc)
-- **would** like to see the shape I submitted
-  - **would** like to see each buy/sell order with it's reference and offset
-  - **would** like to see the current price for each buy/sell
+- **would** like to see the liquidity commitment order status (`pending`, `active`, `parked`, `canceled` etc)
 - **would** like to see the fee bid
+
+- **should** see the whole shape of a liquidity order
+- **must** see the reference and offset for each part liquidity order order (<a name="7003-MORD-017" href="#7003-MORD-017">7003-MORD-017</a>)
+- **should** see the current price for each buy/sell
+- when order is not `Active`: **should** show the order status (perhaps instead of price)
+- **should** see link to cancel the whole liquidity order shape (see [liquidity provision](5002-LIQP-provide_liquidity.md))
+- **would** like to see link to edit the shape of a pegged order (see [liquidity provision](5002-LIQP-provide_liquidity.md))
 - **would** like to see the date submitted/updated
 
 ... so I can decide if I wish to amend or cancel my shape

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -1,9 +1,13 @@
 # Manage orders
 
 Users place orders to describe the trades they would like to make: buy or sell, at what price, how long it is valid for etc. In many cases they can edit these orders while they are still active, for example: changing price.
+
 Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order cannot be edited on canceled in the same way as other orders.
+
 Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) e.g. whether it has been accepted, filled, how close it is to being filled etc.
+
 Markets also have [statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect how I perceive the state of an order, e.g if the order was placed while in "normal" continuous trading, but the market is now in auction. 
+
 Users may be interested in the price of their orders relative to the price of the market.
 
 ## Orders list

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -1,6 +1,6 @@
 # Manage orders
 
-Users place orders to describe the trades they would like to make: buy or sell, at what price, how long it is valid for etc. In many cases they can [ammend](#amend-order---price) or [cancel](#cancel-orders) these orders while they are still active, for example: changing price.
+Users place orders to describe the trades they would like to make: buy or sell, at what price, how long it is valid for etc. In many cases they can [amend](#amend-order---price) or [cancel](#cancel-orders) these orders while they are still active, for example: changing price.
 
 Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) in a [list](#orders-list) of other orders. e.g. whether it has been accepted, filled, how close it is to being filled etc. Users may be interested in the price of their orders relative to the price of the market and how much of the order's size has been filled.
 
@@ -20,7 +20,7 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 ### Fields
 
-- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order, because... (<a name="7003-MORD-001" href="#7003-MORD-001">7003-MORD-001</a>)
+- **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order, and therefore... (<a name="7003-MORD-001" href="#7003-MORD-001">7003-MORD-001</a>)
   - `Active​`
     - How much of the order is filled / remains unfilled
     - How close the mark price is to order

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -23,8 +23,8 @@ User will have differing needs/preferences in terms of what they want to see abo
 - **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order, because...
   - `Active​`
     - How much of the order is filled / remains unfilled
-    - How close the mark price is to my order
-    - If this order is filled at the limit price what would my what effect would it have on realized PnL 
+    - How close the mark price is to order
+    - If this order was filled at the limit price what would what effect would it have on realized PnL 
     - I may want to amend or cancel this order
   - `Expired​`
     - When did it expire
@@ -51,19 +51,19 @@ User will have differing needs/preferences in terms of what they want to see abo
 - **must** see [order type](9001-DATA-data_display.md#order-type)
 - if order created by [pegged or liquidity provision shape](9001-DATA-data_display.md#order-origin): **should** see order origin
   - **could** see what part of the liquidity shape or pegged order shape this relates to. See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
-  - **could** see link to my full shape
+  - **could** see link to full shape
 
 - **should** see how much of the order's [size](9001-DATA-data_display.md#size) has been filled e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
 - **should** see how much of the order's [size](9001-DATA-data_display.md#size) remains. Note: this does not go to zero if the order status goes to a closed state. TODO double check what the API does in a situation where I got 50% fill then canceled an order 
 
 - if order type = `Limit`: **must** see the Limit [price](9001-DATA-data_display.md#quote-price) that was set on the order
-- if order type = `Market`: **must** not see a price for active or parked orders, a `-`, `Market` or `n/a` is more appropriate (API may return 0).
+- if order type = `Market`: **must** not see a price for active or parked orders, a `-`, `Market` or `n/a` is more appropriate (API may return `0`).
 
 - **must** see the [time in force](9001-DATA-data_display.md#time-in-force) applied to the order (can be abbreviated here)
-- **should** see created At time stamp. TODO check what happens to this in the context of Pegged and LP orders.
+- **should** see "created at" [time](9001-DATA-data_display.md#time). TODO check what happens to this in the context of Pegged and LP orders.
 - **could** see updated at (this is used by the system when an order is amended, or repriced (in pegged and LP) not sure this in needed) TODO check behavior 
 
-- **should** see time/order priority (how many orders are before mine at this price)
+- **should** see time priority (how many orders are before mine at this price)
   
 - if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [amend](#amend-order---price) the individual order
 - if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to amend the individual order
@@ -97,7 +97,7 @@ User will have differing needs/preferences in terms of what they want to see abo
 - **must** select weather to cancel an individual order or all orders on a market
 - **must** be able to submit the [Vega transaction](0003-WTXN-submit_vega_transaction.md) to cancel order(s)
   - **could** show the margin requirement reduction/increase that will take place before submitting
-- **must** see feedback on my order status after the transaction
+- **must** see feedback on order status after the transaction
 
 ## Amend order - price
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -22,9 +22,9 @@ User will have differing needs/preferences in terms of what they want to see abo
 
 - **must** see [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) of the order
   - `Active​`
-    - how much of the order is filled / remains unfilled
-    - how close the mark price is to my order
-    - if this order is filled at the limit price what would my what effect would it have on realized PnL 
+    - How much of the order is filled / remains unfilled
+    - How close the mark price is to my order
+    - If this order is filled at the limit price what would my what effect would it have on realized PnL 
     - I may want to amend or cancel this order
   - `Expired​`
     - When did it expire
@@ -38,11 +38,11 @@ User will have differing needs/preferences in terms of what they want to see abo
   - `Rejected​`
     - Why was this order rejected (show `rejectedReason`)
   - `PartiallyFilled​`
-    - how much was filled before the order was canceled
-    - what was the average fill price I got for this order
+    - How much was filled before the order was canceled
+    - What was the average fill price I got for this order
   - `Parked​`
     - Why is the market currently in auction
-    - link to pegged shape (see bellow) TODO find out what happens to the limit orders in the orders API when market is in auction
+    - Link to pegged shape (see bellow) TODO find out what happens to the limit orders in the orders API when market is in auction
 
 - **must** see what [market](9001-DATA-data_display.md#market) an order is related to (either code, ID or name, preferable name)
   - **should** see what the status is of the market (particularly if it is not "normal")

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -90,6 +90,7 @@ User will have differing needs/preferences in terms of what they want to see abo
 ### Grouping
 
 - **should** be able to group orders by any field e.g. by market, lp etc
+- **should** have default grouping by market
 
 ## Cancel orders
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -149,7 +149,7 @@ when looking at an order book, I...
 When looking to understand the state of a pegged order shape...
 
 - **should** see the whole shape of a pegged order
-- **must** see the reference and offset for each part pegged order (<a name="7003-MORD-016" href="#7003-MORD-016">7003-MORD-016</a>)
+- **must** see the reference, offset and direction for each part pegged order (<a name="7003-MORD-016" href="#7003-MORD-016">7003-MORD-016</a>)
 - **should** see the current price for each buy/sell
 - **should** see the filled/remaining for each part of the order
 - when order is not `Active`: **should** show the order status (perhaps instead of price)
@@ -166,7 +166,7 @@ When looking to understand the state of a liquidity provision, with a provided s
 - **would** like to see the fee bid
 
 - **should** see the whole shape of a liquidity order
-- **must** see the reference and offset for each part liquidity order order (<a name="7003-MORD-017" href="#7003-MORD-017">7003-MORD-017</a>)
+- **must** see the reference, offset and direction for each part liquidity order order (<a name="7003-MORD-017" href="#7003-MORD-017">7003-MORD-017</a>)
 - **should** see the current price for each buy/sell
 - when order is not `Active`: **should** show the order status (perhaps instead of price)
 - **should** see link to cancel the whole liquidity order shape (see [liquidity provision](5002-LIQP-provide_liquidity.md))

--- a/user-interface/9001-DATA-data_display.md
+++ b/user-interface/9001-DATA-data_display.md
@@ -78,3 +78,6 @@ The labels fot these should be shown in full where possible (particularly in con
 ## Order origin
 
 Some limit orders originate not from a "normal" limit order, but are created by the system for the users when they submitted a pegged order shape or a liquidity provision shape.
+
+# Time
+Times are generally converted to the browser's local time. However in some contexts it is important to show what time zone the stated time is in. e.g. governance votes &amp; and settlement

--- a/user-interface/9001-DATA-data_display.md
+++ b/user-interface/9001-DATA-data_display.md
@@ -10,10 +10,14 @@ This is set per-market and represent the number of contracts that are being brou
 
 `Market.positionDecimalPlaces` tells us where to put the decimal when displaying the number. Size can be a whole number if `Market.positionDecimalPlaces` = 0, or a [fractional order](../protocol/0052-FPOS-fractional_orders_positions.md) if > 0.
 It **should** always be displayed to the full number of decimal places. however, there may be exceptions, e.g. when visualizing on a depth chart, where the precision is not required.
+Size can also be prefixed with a + or negative to imply direction/side + for long (aka buy) and - for short (aka sell)  
 
+## Direction / side
+
+Generally with derivatives (as apposed to spot or cash markets) one talks about going Long as apposed to Buying, Short as apposed to Selling.
 ## Quote price
 
-> aka. price, quote, level.
+> aka. price, quote, level, limit price
 
 This is set per-market and represent the "price" of an asset. It can have a 1-1 relationship with the settlement asset but it is also possible that products will have different payoff methods, which is one of the reasons we don't just use settlement asset, another being in the future some markets could have multiple settlement assets, another being that we don't want 18DP quotes.
 
@@ -48,3 +52,29 @@ Vega public keys are hexadecimal, but the convention is to display them without 
 > aka Transaction ID, txn, tx
 
 The transaction [hash](https://www.investopedia.com/terms/h/hash.asp) acts as an identifier for a transaction network. It is hexadecimal and should be displayed with the preceding `0x`.
+
+## Order type
+
+There are different [types of orders](../protocol/0014-ORDT-order_types.md). 
+
+- Limit
+- Market
+- Stop-market *- not currently supported*
+- Stop-limit *- not currently supported*
+
+## Time in force
+
+Different order types can have different time in force options, these allow control over how these are executed.
+
+The labels fot these should be shown in full where possible (particularly in context of a order ticket), But can be abbreviated if spaces is short.
+
+  - Good till canceled `GTC`
+  - Good till time `GTT` 
+  - Fill or kill `FOK` 
+  - Immediate or cancel `IOC`
+  - Good for normal trading only `GFN` 
+  - Good for auction only `GFA` 
+
+## Order origin
+
+Some limit orders originate not from a "normal" limit order, but are created by the system for the users when they submitted a pegged order shape or a liquidity provision shape.

--- a/user-interface/9001-DATA-data_display.md
+++ b/user-interface/9001-DATA-data_display.md
@@ -38,7 +38,7 @@ The is set per Asset and represents the amount of an asset that is held in the b
 
 Markets do not have names, technically it is the instrument within a market that has the name. Theoretically the same instrument can be traded in multiple markets. if/when this happens a user needs to be able to disambiguate between markets. Each market does have a unique ID, Note: this is a hash of the definition of the market when it was created.
 Instruments have both a Name and Code, see [market framework](../protocol/0001-MKTF-market_framework.md) for how these are used. Generally the Code can save space once a user is familiar with the market. The Name is more descriptive and should be the default when discovering markets. It remains to be seen how the community will use these exactly.
-Markets can have several statuses and it may be sensible when listing markets to highlight their status. e.g. if a market is usually in continuous trading mode, but is currently in an auction due to low liquidity. The market name field could be augmented to show the status (add an icon etc).
+Markets can have several [statuses](../protocol/0043-MKTL-market_lifecycle.md) and it may be sensible when listing markets to highlight their status. e.g. if a market is usually in continuous trading mode, but is currently in an auction due to low liquidity. The market name field could be augmented to show the status (add an icon etc).
 
 ## Public keys
 

--- a/user-interface/README.md
+++ b/user-interface/README.md
@@ -69,7 +69,7 @@ These files contain generic user needs for interacting with wallets that are tru
 ## `7000` Collateral, Orders, Positions and Fills 
 - `7001-COLL` [View my collateral / accounts](7001-COLL-collateral.md) `TODO`
 - `7002-SORD` [Submit an order](7002-SORD-submit_orders.md) 
-- `7003-MORD` [Manage my orders](7003-MORD-manage_orders.md) `TODO`
+- `7003-MORD` [Manage my orders](7003-MORD-manage_orders.md)
 - `7004-POSI` [View my positions](7004-POSI-positions.md) `TODO`
 - `7005-FILL` [View my trades/fills](7005-FILL-fills.md) `TODO`
 - `7006-FEES` [View my trading fees](7006-FEES-fees.md) `TODO`

--- a/user-interface/categories.json
+++ b/user-interface/categories.json
@@ -18,12 +18,15 @@
         "specs": ["5001-LIQF", "5002-LIQP", "5003-LIQI"]
     },
     "Markets and analysis": {
-        "specs": ["6001-MARK", "6002-MARD", "6003-ORDB", "6004-PHIS", "6005-THIS"]
+        "specs": ["6001-MARK", "6002-MDET", "6003-ORDB", "6004-PHIS", "6005-THIS"]
     },
     "Collateral, Orders, Positions and Fills": {
         "specs": ["7001-COLL", "7002-SORD", "7003-MORD", "7004-POSI", "7005-FILL", "7006-FEES"]
     },
     "Block exploring": {
         "specs": ["8001-BLOX"]
+    },
+    "Data format": {
+        "specs": ["9001-DATA"]
     }
  }


### PR DESCRIPTION
this adds content (acceptance criteria) to the Manage orders file. 
and fixes the codes for SORD
and fixes an issue with the categories

- [readable preview](https://github.com/vegaprotocol/specs/blob/user-interface-add-MORD-manage-order-content/user-interface/7003-MORD-manage_orders.md)

closes: https://github.com/vegaprotocol/ux-and-visual-design/issues/16

- [x] link to issue
- [x] Draft all Sections
- [x] TODOs check core behaviour(s)
- [x] proof
- [ ] sense check from someone who knows
- [x] review
- [x] Add ACs
- [x] check all links
- [x] run check-codes
