### PR TITLE
User interface: `WITH` Withdrawals

### DIFF
--- a/user-interface/0004-EWAL-connect_ethereum_wallet.md
+++ b/user-interface/0004-EWAL-connect_ethereum_wallet.md
@@ -9,18 +9,18 @@ When wanting or needing to write to Ethereum, I...
 - **must** see a link to connect that opens connection options
 
 - if first time:
-  - **must** select a connection method / wallet type: (e.g. wallet connect, injected / metamask)
-  - **must** be prompt to check eth wallet (while the dapp waits for a response)
-  - **must** see an option to cancel the attempted connection (if the wallet fails to respond)
+  - **must** select a connection method / wallet type: (e.g. wallet connect, injected / metamask) (<a name="0004-EWAL-001" href="#0004-EWAL-001">0004-EWAL-001</a>)
+  - **must** be prompt to check eth wallet (while the dapp waits for a response) (<a name="0004-EWAL-002" href="#0004-EWAL-002">0004-EWAL-002</a>)
+  - **must** see an option to cancel the attempted connection (if the wallet fails to respond) (<a name="0004-EWAL-003" href="#0004-EWAL-003">0004-EWAL-003</a>)
   - if the app gets multiple keys the user: 
     - **should** be shown the keys returned and given a UI to select a key for use
     - **should** be prompted to select one (in many cases Dapps default to key 0 in the array)
 - after first use (if there is a connection to restore):
-  - **must** prompt wallet to grant access
+  - **must** prompt wallet to grant access (<a name="0004-EWAL-004" href="#0004-EWAL-004">0004-EWAL-004</a>)
   - **should** see previous connection has been recovered
   - **should** see a link to trigger a fresh connection / fetch new keys (in in the case where I now want to use a different wallet to the one I was connected with) [[[TBD Link to ac about multi key select]]]
 - once connected:
-  - **must** see the connected ethereum wallet [Public key](7001-DATA-data_display.md#public-keys) 
+  - **must** see the connected ethereum wallet [Public key](7001-DATA-data_display.md#public-keys) (<a name="0004-EWAL-005" href="#0004-EWAL-005">0004-EWAL-005</a>)
 
 ... so I can sign and broadcast Ethereum transactions, use a key address as in input, or read data from ethereum via my connected wallet 
 
@@ -28,8 +28,8 @@ When wanting or needing to write to Ethereum, I...
 
 When I'm finished using a connected Ethereum wallet I may wish to disconnect...
 
-- **must** see a link to disconnect 
-- **must** destroy all session so that hitting connect again connects as if it is the first use
+- **must** see a link to disconnect  (<a name="0004-EWAL-006" href="#0004-EWAL-006">0004-EWAL-006</a>)
+- **must** destroy all session so that hitting connect again connects as if it is the first use (<a name="0004-EWAL-007" href="#0004-EWAL-007">0004-EWAL-007</a>)
 - **should** see a connect button to start a fresh connection (e.g. to a different wallet but via Wallet connect)
 
 ... so that I can use a different wallet, or ensure may wallet can not be used by other apps 

--- a/user-interface/0004-EWAL-connect_ethereum_wallet.md
+++ b/user-interface/0004-EWAL-connect_ethereum_wallet.md
@@ -6,21 +6,21 @@ Dapps can connect to an Ethereum wallet to complete Ethereum transactions such a
 
 When wanting or needing to write to Ethereum, I...
 
-- **must** see a link to connect that opens connection options
+- will have seen a link to connect that opens connection options (this always happens in context so should be covered by WITH, DEPO, ASSO ACS)
 
 - if first time:
   - **must** select a connection method / wallet type: (e.g. wallet connect, injected / metamask) (<a name="0004-EWAL-001" href="#0004-EWAL-001">0004-EWAL-001</a>)
   - **must** be prompt to check eth wallet (while the dapp waits for a response) (<a name="0004-EWAL-002" href="#0004-EWAL-002">0004-EWAL-002</a>)
   - **must** see an option to cancel the attempted connection (if the wallet fails to respond) (<a name="0004-EWAL-003" href="#0004-EWAL-003">0004-EWAL-003</a>)
-  - if the app gets multiple keys the user: 
-    - **should** be shown the keys returned and given a UI to select a key for use
+  - if the app gets multiple keys: the user: 
+    - **should** be shown the keys returned and given a UI to select a key for use (but the pattern is often just to select the first in the array)
     - **should** be prompted to select one (in many cases Dapps default to key 0 in the array)
 - after first use (if there is a connection to restore):
   - **must** prompt wallet to grant access (<a name="0004-EWAL-004" href="#0004-EWAL-004">0004-EWAL-004</a>)
   - **should** see previous connection has been recovered
-  - **should** see a link to trigger a fresh connection / fetch new keys (in in the case where I now want to use a different wallet to the one I was connected with) [[[TBD Link to ac about multi key select]]]
+  - **should** see a link to trigger a fresh connection / fetch new keys (in in the case where I now want to use a different wallet to the one I was connected with)
 - once connected:
-  - **must** see the connected ethereum wallet [Public key](7001-DATA-data_display.md#public-keys) (<a name="0004-EWAL-005" href="#0004-EWAL-005">0004-EWAL-005</a>)
+  - **must** see the connected ethereum wallet Public key (<a name="0004-EWAL-005" href="#0004-EWAL-005">0004-EWAL-005</a>)
 
 ... so I can sign and broadcast Ethereum transactions, use a key address as in input, or read data from ethereum via my connected wallet 
 

--- a/user-interface/0004-EWAL-connect_ethereum_wallet.md
+++ b/user-interface/0004-EWAL-connect_ethereum_wallet.md
@@ -1,1 +1,35 @@
-# Connect ethereum wallet
+# Connect Ethereum wallet
+
+Dapps can connect to an Ethereum wallet to complete Ethereum transactions such as Deposits and withdraws to/from Vega,  Association and more.
+
+## Connecting wallet
+
+When wanting or needing to write to Ethereum, I...
+
+- **must** see a link to connect that opens connection options
+
+- if first time:
+  - **must** select a connection method / wallet type: (e.g. wallet connect, injected / metamask)
+  - **must** be prompt to check eth wallet (while the dapp waits for a response)
+  - **must** see an option to cancel the attempted connection (if the wallet fails to respond)
+  - if the app gets multiple keys the user: 
+    - **should** be shown the keys returned and given a UI to select a key for use
+    - **should** be prompted to select one (in many cases Dapps default to key 0 in the array)
+- after first use (if there is a connection to restore):
+  - **must** prompt wallet to grant access
+  - **should** see previous connection has been recovered
+  - **should** see a link to trigger a fresh connection / fetch new keys (in in the case where I now want to use a different wallet to the one I was connected with) [[[TBD Link to ac about multi key select]]]
+- once connected:
+  - **must** see the connected ethereum wallet [Public key](7001-DATA-data_display.md#public-keys) 
+
+... so I can sign and broadcast Ethereum transactions, use a key address as in input, or read data from ethereum via my connected wallet 
+
+## Disconnecting
+
+When I'm finished using a connected Ethereum wallet I may wish to disconnect...
+
+- **must** see a link to disconnect 
+- **must** destroy all session so that hitting connect again connects as if it is the first use
+- **should** see a connect button to start a fresh connection (e.g. to a different wallet but via Wallet connect)
+
+... so that I can use a different wallet, or ensure may wallet can not be used by other apps 

--- a/user-interface/0005-ETXN-submit_ethereum_transaction.md
+++ b/user-interface/0005-ETXN-submit_ethereum_transaction.md
@@ -1,1 +1,56 @@
-# Submit ethereum transaction
+# Submit Ethereum transaction
+
+## Know transaction I'm signing
+When about to click to prompt Ethereum wallet to sign a transaction, I...
+
+- **should** see the contract address I am about to interact with
+- **should** see the function name I am about to interact with
+
+...so I know what to expect when my wallet asks me to sign
+## Track transactions to wallet
+
+after clicking to submit an eth transaction to a connected wallet, I...
+
+- **could** see an indication of current gas prices compared to a recent history
+- **could** see an estimated gas price for the function in question
+- **must** see prompt to check Ethereum wallet to approve transactions
+
+... so I know I need to go to my wallet app to approve the transaction
+
+## ERC20 approval/permit
+
+> The approval/permit step is part of the [ERC20 standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/). It's intention is to provide additional security when interacting with smart contracts / using Dapps. It sets a maximum amount that the given eth key can send to a given address. It means that before end "spend" of ERC20 tokens I will have need to submit a "approve" transaction to tell the network how much is approved. An attempt to spend more than the approved amount will fail.
+> For example: In my approve transaction, I approve 10, I then spend 5. In my next transaction I attempt to spend 6, this will fail as my approve amount was reduced by the first transaction.
+> It is common for dapps to have a approve button that simply asks to approve a massive amount and leave it up to the wallet UI (e.g. metamask) to ask the user if they would like to change this. 
+> Some ERC20 contracts have an additional function that runs both the approve and deposit function in one, but this is not standard.
+
+If the transaction in question requires an ERC20 approval, I...
+
+- if the current approved amount is less than the amount being "spent": **must** see be prompt to approve 
+- **could** see the current approved amount
+- **should** be able to set the amount to be approved (incase the connected wallet does not handle this)
+- **must** send an approve transaction with either a user specified amount or a very large number
+- **must** see feedback of the state of approve transaction see "tracking ethereum transactions" below.
+
+... so I can control the maximum permitted transfer to the contract in question
+
+## Tracking Ethereum transactions on network
+
+After approving a transaction in my wallet app, I...
+
+- **should** see link to the transaction on etherscan
+- **must** see the transactions status (Pending, confirmed, etc) on Ethereum by reading Ethereum (via connected wallet or the back up node specified in the app) 
+- if failed: **must** see why the transaction failed (e.g. didn't pay enough gas)
+- if success: **should** see how many blocks ago the transaction was confirmed by the eth node being read
+
+... so I can see the status of the transaction and debug as appropriate
+## Tracking Ethereum transactions having their affect on Vega
+Note: it is common for inter-blockchain applications to wait a certain amount of blocks before crediting money, as this reduces the risk of double spend in the case of forks or chain roll backs. There is a Vega environment variable the defines how long Vega waits.
+
+If the ethereum transaction I've just submitted changes the state of the Vega network (e.g. a deposit from eth appearing as credited to my vega key on vega), I...
+
+- **should** see how many Ethereum blocks Vega needs to wait before changing the state of Vega
+- **should** see how many blocks have passed or remain until the required number has been met
+- **must** see whether the expect action has taken place on Vega (e.g. credited Vega key)
+
+... so I know vega has been updated as appropriate 

--- a/user-interface/0005-ETXN-submit_ethereum_transaction.md
+++ b/user-interface/0005-ETXN-submit_ethereum_transaction.md
@@ -1,6 +1,6 @@
 # Submit Ethereum transaction
 
-## Know transaction I'm signing
+## Know what transaction I'm signing
 When about to click to prompt Ethereum wallet to sign a transaction, I...
 
 - **should** see the contract address I am about to interact with

--- a/user-interface/0005-ETXN-submit_ethereum_transaction.md
+++ b/user-interface/0005-ETXN-submit_ethereum_transaction.md
@@ -11,7 +11,7 @@ When about to click to prompt Ethereum wallet to sign a transaction, I...
 
 after clicking to submit an eth transaction to a connected wallet, I...
 
-- **could** see an indication of current gas prices compared to a recent history
+- **could** see an estimate for gas prices compared to a recent history
 - **could** see an estimated gas price for the function in question
 - **must** see prompt to check Ethereum wallet to approve transactions
 

--- a/user-interface/0005-ETXN-submit_ethereum_transaction.md
+++ b/user-interface/0005-ETXN-submit_ethereum_transaction.md
@@ -28,7 +28,7 @@ If the transaction in question requires an ERC20 approval, I...
 
 - if the current approved amount is less than the amount being "spent": **must** see be prompt to approve 
 - **could** see the current approved amount
-- **should** be able to set the amount to be approved (incase the connected wallet does not handle this)
+- **must** be able to set the amount to be approved (in case the connected wallet does not handle this) (<a name="0005-ETXN-006" href="#0005-ETXN-006">0005-ETXN-006</a>)
 - **must** send an approve transaction with either a user specified amount or a very large number (<a name="0005-ETXN-001" href="#0005-ETXN-001">0005-ETXN-001</a>)
 - **must** see feedback of the state of approve transaction see "tracking ethereum transactions" below. (<a name="0005-ETXN-002" href="#0005-ETXN-002">0005-ETXN-002</a>)
 

--- a/user-interface/0005-ETXN-submit_ethereum_transaction.md
+++ b/user-interface/0005-ETXN-submit_ethereum_transaction.md
@@ -29,8 +29,8 @@ If the transaction in question requires an ERC20 approval, I...
 - if the current approved amount is less than the amount being "spent": **must** see be prompt to approve 
 - **could** see the current approved amount
 - **should** be able to set the amount to be approved (incase the connected wallet does not handle this)
-- **must** send an approve transaction with either a user specified amount or a very large number
-- **must** see feedback of the state of approve transaction see "tracking ethereum transactions" below.
+- **must** send an approve transaction with either a user specified amount or a very large number (<a name="0005-ETXN-001" href="#0005-ETXN-001">0005-ETXN-001</a>)
+- **must** see feedback of the state of approve transaction see "tracking ethereum transactions" below. (<a name="0005-ETXN-002" href="#0005-ETXN-002">0005-ETXN-002</a>)
 
 ... so I can control the maximum permitted transfer to the contract in question
 
@@ -39,8 +39,8 @@ If the transaction in question requires an ERC20 approval, I...
 After approving a transaction in my wallet app, I...
 
 - **should** see link to the transaction on etherscan
-- **must** see the transactions status (Pending, confirmed, etc) on Ethereum by reading Ethereum (via connected wallet or the back up node specified in the app) 
-- if failed: **must** see why the transaction failed (e.g. didn't pay enough gas)
+- **must** see the transactions status (Pending, confirmed, etc) on Ethereum by reading Ethereum (via connected wallet or the back up node specified in the app) (<a name="0005-ETXN-003" href="#0005-ETXN-003">0005-ETXN-003</a>)
+- if failed: **must** see why the transaction failed (e.g. didn't pay enough gas) (<a name="0005-ETXN-004" href="#0005-ETXN-004">0005-ETXN-004</a>)
 - if success: **should** see how many blocks ago the transaction was confirmed by the eth node being read
 
 ... so I can see the status of the transaction and debug as appropriate
@@ -51,6 +51,6 @@ If the ethereum transaction I've just submitted changes the state of the Vega ne
 
 - **should** see how many Ethereum blocks Vega needs to wait before changing the state of Vega
 - **should** see how many blocks have passed or remain until the required number has been met
-- **must** see whether the expect action has taken place on Vega (e.g. credited Vega key)
+- **must** see whether the expect action has taken place on Vega (e.g. credited Vega key) (<a name="0005-ETXN-005" href="#0005-ETXN-005">0005-ETXN-005</a>)
 
 ... so I know vega has been updated as appropriate 

--- a/user-interface/1002-WITH-withdraw.md
+++ b/user-interface/1002-WITH-withdraw.md
@@ -37,7 +37,7 @@ Note: balances can change frequently when users have open positions. Apps should
   - **should** be able to withdraw to a different Ethereum key to the one the app is connected to
   - **should** be warned if the input does not look like an ethereum address (wrong number of digits, not starting with 0x etc)
 
-- if there is a withdraw delay on the selected [asset](9001-DATA-data_display.md#asset-balances):
+- if there is a withdraw delay on the selected asset:
   - **should** see what the withdraw delay is in hours and mins (if hit)
   - **should** see how large a withdrawal (or sum of withdrawals) needs to be to hit the `withdraw delay threshold`
   - **should** see how much I have withdrawn in the last `withdraw delay period`

--- a/user-interface/1002-WITH-withdraw.md
+++ b/user-interface/1002-WITH-withdraw.md
@@ -8,7 +8,7 @@ See [Specs for eth bridge](../protocol/0031-ETHB-ethereum_bridge_spec.md) and [d
 
 When wishing to withdraw some of an ERC20 asset from Vega, I...
 
-- **should** be prompted to complete any existing incomplete withdrawals that exist for connected keys (see [complete withdrawal](#complete-erc20-withdraw-on-ethereum))
+- **should** be prompted to complete any existing incomplete withdrawals that exist for connected keys (see [complete withdrawal](#complete-erc20-withdraw-from-ethereum-bridge)))
 
 Note: It is better to encourage the completion of started withdraws as soon as possible after starting them. This is because the validator set could theoretically change enough to make the node signatures that authorize the withdrawal invalid.
 
@@ -18,13 +18,13 @@ Note: It is better to encourage the completion of started withdraws as soon as p
 Note: A user may want to delay preparing a withdrawal if gas fees on the network are particularly high at the time
 
 - **must** select the asset to withdraw (<a name="1002-WITH-001" href="#1002-WITH-001">1002-WITH-001</a>)
-  - **should not** see option to select assets where I a zero [total balance](7001-DATA-data_display.md#asset-balances) (note this should also avoid `Pending` assets from appearing in the list)
+  - **should not** see option to select assets where I a zero [total balance](9001-DATA-data_display.md#asset-balances) (note this should also avoid `Pending` assets from appearing in the list)
   - **must** see the general balance I have for that asset (<a name="1002-WITH-002" href="#1002-WITH-002">1002-WITH-002</a>)
   - **should** see balances to the full number of decimal places possible for that asset
   - **should** see the total balances of the assets I have
   - **could** see a breakdown of other accounts I have in this asset and their balances
 
-- **must** select the [amount](7001-DATA-data_display.md#asset-balances) of the asset I wish to withdraw (<a name="1002-WITH-003" href="#1002-WITH-003">1002-WITH-003</a>)
+- **must** select the [amount](9001-DATA-data_display.md#asset-balances) of the asset I wish to withdraw (<a name="1002-WITH-003" href="#1002-WITH-003">1002-WITH-003</a>)
   - **should** have an easy option (link/button) to withdraw the full amount in general balance (e.g. pre-populate the amount input)
   - **must** be able to specify as many decimal places as the asset supports (<a name="1002-WITH-004" href="#1002-WITH-004">1002-WITH-004</a>)
 - **must** be warned if the amount is greater than general balance (<a name="1002-WITH-005" href="#1002-WITH-005">1002-WITH-005</a>)
@@ -37,7 +37,7 @@ Note: balances can change frequently when users have open positions. Apps should
   - **should** be able to withdraw to a different Ethereum key to the one the app is connected to
   - **should** be warned if the input does not look like an ethereum address (wrong number of digits, not starting with 0x etc)
 
-- if there is a withdraw delay on the selected [asset](7001-DATA-data_display.md#asset-balances):
+- if there is a withdraw delay on the selected [asset](9001-DATA-data_display.md#asset-balances):
   - **should** see what the withdraw delay is in hours and mins (if hit)
   - **should** see how large a withdrawal (or sum of withdrawals) needs to be to hit the `withdraw delay threshold`
   - **should** see how much I have withdrawn in the last `withdraw delay period`

--- a/user-interface/1002-WITH-withdraw.md
+++ b/user-interface/1002-WITH-withdraw.md
@@ -8,7 +8,7 @@ See [Specs for eth bridge](../protocol/0031-ETHB-ethereum_bridge_spec.md) and [d
 
 When wishing to withdraw some of an ERC20 asset from Vega, I...
 
-- **should** be prompted to complete any existing incomplete withdrawals that exist for connected keys (see [complete withdrawal](#complete-erc20-withdraw-from-ethereum-bridge)))
+- **should** be prompted to complete any existing incomplete withdrawals that exist for connected keys (see [complete withdrawal](#complete-erc20-withdraw-from-ethereum-bridge))
 
 Note: It is better to encourage the completion of started withdraws as soon as possible after starting them. This is because the validator set could theoretically change enough to make the node signatures that authorize the withdrawal invalid.
 

--- a/user-interface/1002-WITH-withdraw.md
+++ b/user-interface/1002-WITH-withdraw.md
@@ -1,4 +1,5 @@
 # Withdraw
+
 Withdrawing funds is a two step process. First the Vega network needs to approve that the funds can be released (not required for margin on open positions or in liquidity bond etc), this also sets the address that the withdraw will be credited to. Then the user will need to run a function on bridge contract to release the funds from the bridge contract they were deposited too (and pay the gas to do so). They do this using a signature supplied by nodes of the Vega network in Step 1. Although this is a two step process technically effort should be put into making it feel like one, then handle exceptions (like delays on withdrawals) as required.
 
 See [Specs for eth bridge](../protocol/0031-ETHB-ethereum_bridge_spec.md) and [docs](https://docs.vega.xyz/docs/mainnet/concepts/vega-protocol#withdrawals) on withdrawals. See also the [specs on delays to withdrawals](../non-protocol-specs/0003-NP-LIMI-limits_aka_training_wheels.md#withdrawal-limits).
@@ -16,22 +17,22 @@ Note: It is better to encourage the completion of started withdraws as soon as p
 
 Note: A user may want to delay preparing a withdrawal if gas fees on the network are particularly high at the time
 
-- **must** select the asset to withdraw
+- **must** select the asset to withdraw (<a name="1002-WITH-001" href="#1002-WITH-001">1002-WITH-001</a>)
   - **should not** see option to select assets where I a zero [total balance](7001-DATA-data_display.md#asset-balances) (note this should also avoid `Pending` assets from appearing in the list)
-  - **must** see the general balance I have for that asset
+  - **must** see the general balance I have for that asset (<a name="1002-WITH-002" href="#1002-WITH-002">1002-WITH-002</a>)
   - **should** see balances to the full number of decimal places possible for that asset
   - **should** see the total balances of the assets I have
   - **could** see a breakdown of other accounts I have in this asset and their balances
 
-- **must** select the [amount](7001-DATA-data_display.md#asset-balances) of the asset I wish to withdraw
+- **must** select the [amount](7001-DATA-data_display.md#asset-balances) of the asset I wish to withdraw (<a name="1002-WITH-003" href="#1002-WITH-003">1002-WITH-003</a>)
   - **should** have an easy option (link/button) to withdraw the full amount in general balance (e.g. pre-populate the amount input)
-  - **must** be able to specify as many decimal places as the asset supports
-- **must** be warned if the amount is greater than general balance
+  - **must** be able to specify as many decimal places as the asset supports (<a name="1002-WITH-004" href="#1002-WITH-004">1002-WITH-004</a>)
+- **must** be warned if the amount is greater than general balance (<a name="1002-WITH-005" href="#1002-WITH-005">1002-WITH-005</a>)
 - **should** see a link to a faucet on the selected asset (only if there is one)
 
 Note: balances can change frequently when users have open positions. Apps should show up to date information (subscription), and make it easy to fill in the amount this isn't going to make the input invalid as the amount in general balances changes.
 
-- **must** specify the Ethereum address that can claim the withdrawal (e.g. where you are withdrawing too)
+- **must** specify the Ethereum address that can claim the withdrawal (e.g. where you are withdrawing too) (<a name="1002-WITH-006" href="#1002-WITH-006">1002-WITH-006</a>)
   - **should** be able to easily select an Ethereum key the app is already connected to
   - **should** be able to withdraw to a different Ethereum key to the one the app is connected to
   - **should** be warned if the input does not look like an ethereum address (wrong number of digits, not starting with 0x etc)
@@ -40,21 +41,21 @@ Note: balances can change frequently when users have open positions. Apps should
   - **should** see what the withdraw delay is in hours and mins (if hit)
   - **should** see how large a withdrawal (or sum of withdrawals) needs to be to hit the `withdraw delay threshold`
   - **should** see how much I have withdrawn in the last `withdraw delay period`
-  - **must** be warned if this withdraw will hit a the delay
+  - **must** be warned if this withdraw will hit a the delay before hitting withdraw (<a name="1002-WITH-007" href="#1002-WITH-007">1002-WITH-007</a>)
 
-- **must** be warned if there are known reasons that the prepared withdrawal will not work
-- **must** submit a withdraw [vega transaction](0003-WTXN-submit_vega_transaction.md)
+- **must** be warned if there are known reasons that the prepared withdrawal will not work (<a name="1002-WITH-008" href="#1002-WITH-008">1002-WITH-008</a>)
+- **must** submit a withdraw [vega transaction](0003-WTXN-submit_vega_transaction.md) (<a name="1002-WITH-009" href="#1002-WITH-009">1002-WITH-009</a>)
 
 - if the preparing the withdraw on Vega fails:
-  - **must** be directed back to the withdraw form (containing the submitted values) and see an explanation of why the transaction failed, so I can fix and resubmit
+  - **must** be directed back to the withdraw form (containing the submitted values) and see an explanation of why the transaction failed, so I can fix and resubmit (<a name="1002-WITH-010" href="#1002-WITH-010">1002-WITH-010</a>)
 
 - if the preparing the withdraw on Vega is successful:
-  -  **must** see that withdraw is complete
+  -  **must** see that withdraw is complete (<a name="1002-WITH-011" href="#1002-WITH-011">1002-WITH-011</a>)
   - if this withdraw will not hit the withdrawal threshold:
     - **should** be prompted to complete the transaction on ethereum (see [complete ERC20 withdraw](#complete-erc20-withdraw-from-ethereum-bridge))
     - **could** be directed to a list of incomplete withdrawals
   - if this withdraw will hit withdrawal threshold: 
-    - **must** see that the withdraw has been complete and is in the list waiting for the delay to pass
+    - **must** see that the withdraw has been complete and is in the list waiting for the delay to pass (<a name="1002-WITH-011" href="#1002-WITH-011">1002-WITH-011</a>)
 
 ...so that I can get the details required to release my funds from the the Ethereum ERC20 bridge.
 
@@ -65,18 +66,18 @@ When looking to either complete a withdraw or view past withdraws, I...
 - **must** be able to navigate to a list prepared withdrawals for the [connected to a vega wallet + key(s)](0002-WCON-connect_vega_wallet.md)
 
 - for each prepared withdraw:
-  - **must** see the asset being withdrawn
-  - **must** see the [amount](7001-DATA-data_display.md#asset-balances) being withdrawn
-  - **must** see the destination of the withdrawal (e.g. Recipient Eth address)
+  - **must** see the asset being withdrawn (<a name="1002-WITH-012" href="#1002-WITH-012">1002-WITH-012</a>)
+  - **must** see the [amount](7001-DATA-data_display.md#asset-balances) being withdrawn (<a name="1002-WITH-013" href="#1002-WITH-013">1002-WITH-013</a>)
+  - **must** see the destination of the withdrawal (e.g. Recipient Eth address) (<a name="1002-WITH-014" href="#1002-WITH-014">1002-WITH-014</a>)
   - **should** see the date with withdraw was prepared
   - **could** see the full signature bundle from Vega node (for use on Ethereum)
   - for withdraws that are in progress:
-    - **must** see the status of the withdraw (e.g. pending)
+    - **must** see the status of the withdraw (e.g. pending) (<a name="1002-WITH-015" href="#1002-WITH-015">1002-WITH-015</a>)
   - for completed withdraws:
     - **could** see when it was completed on native chain (e.g. ethereum)
-    - **must** see a link to the transaction on native block explorer (e.g. etherscan)
+    - **must** see a link to the transaction on native block explorer (e.g. etherscan) (<a name="1002-WITH-016" href="#1002-WITH-016">1002-WITH-016</a>)
   - for withdraws that have not been completed on the external chain, but are not delayed (e.g. Ethereum):
-    - **must** see a link to complete the withdraw. See [complete ERC20 withdrawal](#complete-erc20-withdraw-from-ethereum-bridge).
+    - **must** see a link to complete the withdraw. See [complete ERC20 withdrawal](#complete-erc20-withdraw-from-ethereum-bridge) (<a name="1002-WITH-017" href="#1002-WITH-017">1002-WITH-017</a>)
   - for withdrawals that have a delay in place before the transaction can be completed:
     - **should** see much of the delay remains before it can be completed
 
@@ -86,19 +87,19 @@ When looking to either complete a withdraw or view past withdraws, I...
 
 When looking to submit the Ethereum transaction to release funds from the Vega bridge into my Ethereum wallet, I...
 
-- **must** see a link to [connect an ethereum wallet](0004-EWAL-connect_ethereum_wallet.md) if not already connected
-- **must** see a link to [submit the ethereum transaction to finish withdrawal](0005-ETXN-submit_ethereum_transaction.md)
+- **must** see a link to [connect an ethereum wallet](0004-EWAL-connect_ethereum_wallet.md) if not already connected (<a name="1002-WITH-018" href="#1002-WITH-018">1002-WITH-018</a>)
+- **must** see a link to [submit the ethereum transaction to finish withdrawal](0005-ETXN-submit_ethereum_transaction.md) (<a name="1002-WITH-019" href="#1002-WITH-019">1002-WITH-019</a>)
 - **could** be warned if the connected ethereum wallet is different to the one that the withdraw is going to credit
 
 Note: this is permitted but is a good reminder to the user about what to expect
 
 - if successful: 
-  - **must** see asset balances have been updated post withdrawal
-  - **must** see the list of withdrawals (with updated status)
+  - **must** see asset balances have been updated post withdrawal (<a name="1002-WITH-020" href="#1002-WITH-020">1002-WITH-020</a>)
+  - **must** see the list of withdrawals (with updated status) (<a name="1002-WITH-021" href="#1002-WITH-021">1002-WITH-021</a>)
   - **could** see prompt to start another transaction or complete another incomplete one 
 - if failed:
-  - **must** see a description of why the transaction failed, and advised what to do (e.g. bad signature)
-  - **must** be returned to a state where I can correct anything that is wrong, and attempt to submit the transaction again
+  - **must** see a description of why the transaction failed, and advised what to do (e.g. bad signature) (<a name="1002-WITH-022" href="#1002-WITH-022">1002-WITH-022</a>)
+  - **must** be returned to a state where I can correct anything that is wrong, and attempt to submit the transaction again (<a name="1002-WITH-023" href="#1002-WITH-023">1002-WITH-023</a>)
   - **should** see a link to docs about withdrawals for trouble shooting (e.g. if the signer set has changed significantly since the withdraw was prepared)
   - **should** see status of incomplete withdrawals (so I can confirm the withdraw I attempted to complete is incomplete)
 

--- a/user-interface/1002-WITH-withdraw.md
+++ b/user-interface/1002-WITH-withdraw.md
@@ -55,7 +55,7 @@ Note: balances can change frequently when users have open positions. Apps should
     - **should** be prompted to complete the transaction on ethereum (see [complete ERC20 withdraw](#complete-erc20-withdraw-from-ethereum-bridge))
     - **could** be directed to a list of incomplete withdrawals
   - if this withdraw will hit withdrawal threshold: 
-    - **must** see that the withdraw has been complete and is in the list waiting for the delay to pass (<a name="1002-WITH-011" href="#1002-WITH-011">1002-WITH-011</a>)
+    - **must** see that the withdraw has been complete and is in the list waiting for the delay to pass (<a name="1002-WITH-024" href="#1002-WITH-024">1002-WITH-024</a>)
 
 ...so that I can get the details required to release my funds from the the Ethereum ERC20 bridge.
 

--- a/user-interface/1002-WITH-withdraw.md
+++ b/user-interface/1002-WITH-withdraw.md
@@ -1,1 +1,105 @@
 # Withdraw
+Withdrawing funds is a two step process. First the Vega network needs to approve that the funds can be released (not required for margin on open positions or in liquidity bond etc), this also sets the address that the withdraw will be credited to. Then the user will need to run a function on bridge contract to release the funds from the bridge contract they were deposited too (and pay the gas to do so). They do this using a signature supplied by nodes of the Vega network in Step 1. Although this is a two step process technically effort should be put into making it feel like one, then handle exceptions (like delays on withdrawals) as required.
+
+See [Specs for eth bridge](../protocol/0031-ETHB-ethereum_bridge_spec.md) and [docs](https://docs.vega.xyz/docs/mainnet/concepts/vega-protocol#withdrawals) on withdrawals. See also the [specs on delays to withdrawals](../non-protocol-specs/0003-NP-LIMI-limits_aka_training_wheels.md#withdrawal-limits).
+
+## Prepare an ERC20 withdraw from Vega
+
+When wishing to withdraw some of an ERC20 asset from Vega, I...
+
+- **should** be prompted to complete any existing incomplete withdrawals that exist for connected keys (see [complete withdrawal](#complete-erc20-withdraw-on-ethereum))
+
+Note: It is better to encourage the completion of started withdraws as soon as possible after starting them. This is because the validator set could theoretically change enough to make the node signatures that authorize the withdrawal invalid.
+
+- **should** be warned that they will need to pay gas on the withdrawal before starting 
+- **could** show the current gas fees BEFORE preparing the withdrawal (note: this is already a requirement for all [ethereum transactions](0005-ETXN-submit_ethereum_transaction.md)) 
+
+Note: A user may want to delay preparing a withdrawal if gas fees on the network are particularly high at the time
+
+- **must** select the asset to withdraw
+  - **should not** see option to select assets where I a zero [total balance](7001-DATA-data_display.md#asset-balances) (note this should also avoid `Pending` assets from appearing in the list)
+  - **must** see the general balance I have for that asset
+  - **should** see balances to the full number of decimal places possible for that asset
+  - **should** see the total balances of the assets I have
+  - **could** see a breakdown of other accounts I have in this asset and their balances
+
+- **must** select the [amount](7001-DATA-data_display.md#asset-balances) of the asset I wish to withdraw
+  - **should** have an easy option (link/button) to withdraw the full amount in general balance (e.g. pre-populate the amount input)
+  - **must** be able to specify as many decimal places as the asset supports
+- **must** be warned if the amount is greater than general balance
+- **should** see a link to a faucet on the selected asset (only if there is one)
+
+Note: balances can change frequently when users have open positions. Apps should show up to date information (subscription), and make it easy to fill in the amount this isn't going to make the input invalid as the amount in general balances changes.
+
+- **must** specify the Ethereum address that can claim the withdrawal (e.g. where you are withdrawing too)
+  - **should** be able to easily select an Ethereum key the app is already connected to
+  - **should** be able to withdraw to a different Ethereum key to the one the app is connected to
+  - **should** be warned if the input does not look like an ethereum address (wrong number of digits, not starting with 0x etc)
+
+- if there is a withdraw delay on the selected [asset](7001-DATA-data_display.md#asset-balances):
+  - **should** see what the withdraw delay is in hours and mins (if hit)
+  - **should** see how large a withdrawal (or sum of withdrawals) needs to be to hit the `withdraw delay threshold`
+  - **should** see how much I have withdrawn in the last `withdraw delay period`
+  - **must** be warned if this withdraw will hit a the delay
+
+- **must** be warned if there are known reasons that the prepared withdrawal will not work
+- **must** submit a withdraw [vega transaction](0003-WTXN-submit_vega_transaction.md)
+
+- if the preparing the withdraw on Vega fails:
+  - **must** be directed back to the withdraw form (containing the submitted values) and see an explanation of why the transaction failed, so I can fix and resubmit
+
+- if the preparing the withdraw on Vega is successful:
+  -  **must** see that withdraw is complete
+  - if this withdraw will not hit the withdrawal threshold:
+    - **should** be prompted to complete the transaction on ethereum (see [complete ERC20 withdraw](#complete-erc20-withdraw-from-ethereum-bridge))
+    - **could** be directed to a list of incomplete withdrawals
+  - if this withdraw will hit withdrawal threshold: 
+    - **must** see that the withdraw has been complete and is in the list waiting for the delay to pass
+
+...so that I can get the details required to release my funds from the the Ethereum ERC20 bridge.
+
+## Withdraws list / history
+
+When looking to either complete a withdraw or view past withdraws, I...
+
+- **must** be able to navigate to a list prepared withdrawals for the [connected to a vega wallet + key(s)](0002-WCON-connect_vega_wallet.md)
+
+- for each prepared withdraw:
+  - **must** see the asset being withdrawn
+  - **must** see the [amount](7001-DATA-data_display.md#asset-balances) being withdrawn
+  - **must** see the destination of the withdrawal (e.g. Recipient Eth address)
+  - **should** see the date with withdraw was prepared
+  - **could** see the full signature bundle from Vega node (for use on Ethereum)
+  - for withdraws that are in progress:
+    - **must** see the status of the withdraw (e.g. pending)
+  - for completed withdraws:
+    - **could** see when it was completed on native chain (e.g. ethereum)
+    - **must** see a link to the transaction on native block explorer (e.g. etherscan)
+  - for withdraws that have not been completed on the external chain, but are not delayed (e.g. Ethereum):
+    - **must** see a link to complete the withdraw. See [complete ERC20 withdrawal](#complete-erc20-withdraw-from-ethereum-bridge).
+  - for withdrawals that have a delay in place before the transaction can be completed:
+    - **should** see much of the delay remains before it can be completed
+
+... so I can complete withdrawals or find details of previous ones
+
+## Complete ERC20 withdraw from Ethereum bridge
+
+When looking to submit the Ethereum transaction to release funds from the Vega bridge into my Ethereum wallet, I...
+
+- **must** see a link to [connect an ethereum wallet](0004-EWAL-connect_ethereum_wallet.md) if not already connected
+- **must** see a link to [submit the ethereum transaction to finish withdrawal](0005-ETXN-submit_ethereum_transaction.md)
+- **could** be warned if the connected ethereum wallet is different to the one that the withdraw is going to credit
+
+Note: this is permitted but is a good reminder to the user about what to expect
+
+- if successful: 
+  - **must** see asset balances have been updated post withdrawal
+  - **must** see the list of withdrawals (with updated status)
+  - **could** see prompt to start another transaction or complete another incomplete one 
+- if failed:
+  - **must** see a description of why the transaction failed, and advised what to do (e.g. bad signature)
+  - **must** be returned to a state where I can correct anything that is wrong, and attempt to submit the transaction again
+  - **should** see a link to docs about withdrawals for trouble shooting (e.g. if the signer set has changed significantly since the withdraw was prepared)
+  - **should** see status of incomplete withdrawals (so I can confirm the withdraw I attempted to complete is incomplete)
+
+... so the funds I withdrew from Vega are credited to my Ethereum key 

--- a/user-interface/9001-DATA-data_display.md
+++ b/user-interface/9001-DATA-data_display.md
@@ -28,6 +28,9 @@ This is set per-market and represent the "price" of an asset. It can have a 1-1 
 
 The is set per Asset and represents the amount of an asset that is held in the bridge. 
 
+Once deposited assets appear in a `general account`. Other account types are created when opening positions, providing liquidity etc.
+Vega does not return a `total balance` that is a sum of all accounts in a currency, but users will expect to see one. See the [Collateral spec](../protocol/0005-COLL-collateral.md) for other account types.
+
 `Asset.decimals` tells the UIs where to put the decimal place. Ethereum assets often have 18 decimal places, but can have less. Forms where you deposit, withdraw or transfer assets must show all decimal places. It may be appropriate to truncate at a certain number of DP in many cases (e.g. `0.01` instead of `0.012345678912345678` event though `0.001 wBTC` may be worth as much as than `0.01 ETH`). At the moment Vega does not have a source of information that allows conversion of currencies or way of knowing that the significant value of an asset is.
 
 ## Market

--- a/user-interface/README.md
+++ b/user-interface/README.md
@@ -24,13 +24,13 @@ These files contain generic user needs for interacting with wallets that are tru
 
 - `0002-WCON` [Connect Vega wallet to a Dapp & select keys](0002-WCON-connect_vega_wallet.md)
 - `0003-WTXN` [Submit Vega transaction](0003-WTXN-submit_vega_transaction.md) 
-- `0004-EWAL` [Connect Ethereum wallet to a Dapp](0004-EWAL-connect_ethereum_wallet.md) `TODO`
-- `0005-ETXN` [Submit Ethereum transaction](0005-ETXN-submit_ethereum_transaction.md) `TODO`
+- `0004-EWAL` [Connect Ethereum wallet to a Dapp](0004-EWAL-connect_ethereum_wallet.md)
+- `0005-ETXN` [Submit Ethereum transaction](0005-ETXN-submit_ethereum_transaction.md)
 - `0006-NETW` [Network and node selection](0006-NETW-network-and-nodes.md) `TODO`
 
 ## `1000` Bridges, Transfers and Vesting
 - `1001-DEPO` [Deposit](1001-DEPO-desposit.md) `TODO`
-- `1002-WITH` [Withdraw](1002-WITH-withdraw.md) `TODO`
+- `1002-WITH` [Withdraw](1002-WITH-withdraw.md)
 - `1003-TRAN` [Transfer](1003-TRAN-transfer.md) `TODO`
 - `1004-ASSO` [Associate governance token with a Vega key](1004-ASSO-associate.md) `TODO`
 - `1005-VEST` [View and redeem vested tokens](1005-VEST-vesting.md) `TODO`


### PR DESCRIPTION
Adds acceptance criteria for users wanting to withdraw from Vega, along with some general Ethereum interaction ACs.

Nice readable versions:
- [readme / index](https://github.com/vegaprotocol/specs/tree/user-interface-WITH-content/user-interface#user-interface-acceptance-criteria)
- [Withdraw](https://github.com/vegaprotocol/specs/blob/user-interface-WITH-content/user-interface/1002-WITH-withdraw.md) which links to:
- [connect eth wallet](https://github.com/vegaprotocol/specs/blob/user-interface-WITH-content/user-interface/0004-EWAL-connect_ethereum_wallet.md#connect-ethereum-wallet) and
- [Submitting an ethereum transaction](https://github.com/vegaprotocol/specs/blob/user-interface-WITH-content/user-interface/0005-ETXN-submit_ethereum_transaction.md#submit-ethereum-transaction) both of which will be referred to by Associate and Deposit

closes: https://github.com/vegaprotocol/ux-and-visual-design/issues/23

- [x] Draft ETH wallet connect
- [x] Draft ETH txn submit
- [x] Draft ACs for WITH
- [x] proof
- [x] Add ACs
- [x] check all links
- [x] run check-codes
