### PR TITLE
User interface: remove ACs for things that are not musts

### DIFF
--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -79,11 +79,11 @@ When a dapp sends a transaction to the wallet for signing and broadcast, I...
 When looking for a specific balance or asset on a given wallet and network, I...
 
 - **must** see total balances of an asset for each key (<a name="0001-WALL-027" href="#0001-WALL-027">0001-WALL-027</a>)
-- **should** see a breakdown of all accounts for an asset on a key (<a name="0001-WALL-028" href="#0001-WALL-028">0001-WALL-028</a>)
-- **should** see a summary of balances when switching keys (to help me find the key I am looking for) (<a name="0001-WALL-029" href="#0001-WALL-029">0001-WALL-029</a>)
-- **would like to** be able to search by market name/code, and see all keys with a margin or liquidity account in matching markets (<a name="0001-WALL-030" href="#0001-WALL-030">0001-WALL-030</a>)
-- **should** be able to search by asset name or code, and see all keys with balance of matching assets (<a name="0001-WALL-031" href="#0001-WALL-031">0001-WALL-031</a>)
-- **should** be able to search for arbitrary metadata added by user to keys (<a name="0001-WALL-032" href="#0001-WALL-032">0001-WALL-032</a>)
+- **should** see a breakdown of all accounts for an asset on a key
+- **should** see a summary of balances when switching keys
+- **would like to** be able to search by market name/code, and see all keys with a margin or liquidity account in matching markets
+- **should** be able to search by asset name or code, and see all keys with balance of matching assets
+- **should** be able to search for arbitrary metadata added by user to keys
 - **must** be able to see a total of all asset for all keys in a given wallet (<a name="0001-WALL-033" href="#0001-WALL-033">0001-WALL-033</a>)
  
 ... so that I can find the keys that I am looking for, see how much I have to consolidate (via transfers) or withdraw funds
@@ -92,14 +92,7 @@ When looking for a specific balance or asset on a given wallet and network, I...
 When thinking about a recent or specific transaction, I ...
 
 - **must** see a history of transactions the wallet app has signed. As read from the local app (Current "session" only, as persistent data storage has other requirements (see commented out ACs)) (<a name="0001-WALL-034" href="#0001-WALL-034">0001-WALL-034</a>)
-<!--
-- **should** see a history of transactions the wallet app has signed. As read from the local app (persistent storage)
-  - persistent transaction history **must** be encrypted and require the wallet password to view
-  - **should** be possible to delete individual transactions
-  - **should** be possible to delete the whole transaction history
-  - **would** like to set a maximum age / expiry time for history items after which they are deleted
--->
-- **could** see a history of transactions the selected key has broadcast to a network (e.g. another wallet with the same keys), or from before a key restore (<a name="0001-WALL-077" href="#0001-WALL-077">0001-WALL-077</a>)
+- **could** see a history of transactions the selected key has broadcast to a network (e.g. another wallet with the same keys), or from before a key restore
 - **must** see pending transactions (Transactions I have not yet approved/rejected) (<a name="0001-WALL-035" href="#0001-WALL-035">0001-WALL-035</a>)
 - **must** see transactions that have recently been broadcast but not yet seen on the chain (<a name="0001-WALL-036" href="#0001-WALL-036">0001-WALL-036</a>)
 - **must** see transactions that were rejected by the wallet user (me) (<a name="0001-WALL-037" href="#0001-WALL-037">0001-WALL-037</a>)
@@ -120,19 +113,19 @@ when looking at a specific transaction...
 - **must** be prompted to enter passphrase (when needed to sign + broadcast transaction) (<a name="0001-WALL-044" href="#0001-WALL-044">0001-WALL-044</a>)
 - **must** see [status of broadcasted transactions](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network). (<a name="0001-WALL-045" href="#0001-WALL-045">0001-WALL-045</a>)
 - **must** be able to follow a link to block explorer for broadcasted transactions (<a name="0001-WALL-046" href="#0001-WALL-046">0001-WALL-046</a>)
-- if broadcast: **should** see what node it was broadcast to (<a name="0001-WALL-047" href="#0001-WALL-047">0001-WALL-047</a>)
-- if broadcast + mined: **could** see what validator mined the block the transaction was included in (<a name="0001-WALL-048" href="#0001-WALL-048">0001-WALL-048</a>)
+- if broadcast: **should** see what node it was broadcast to
+- if broadcast + mined: **could** see what validator mined the block the transaction was included in
 - if broadcast + mined: **must** see at what block and time it was confirmed (<a name="0001-WALL-049" href="#0001-WALL-049">0001-WALL-049</a>)
-- if broadcast but there was an error: **must** see if there was a reported error/issue, and the details of the issue (<a name="0001-WALL-050" href="#0001-WALL-050">0001-WALL-050</a>)
-- if broadcast + mined: **must** see if the transaction was rejected, and why (<a name="0001-WALL-051" href="#0001-WALL-051">0001-WALL-051</a>)
-- if ignored: must be able to submit, reject or still ignore the transaction (<a name="0001-WALL-079" href="#0001-WALL-079">0001-WALL-079</a>)
+- if broadcast but there was an error: **must** see if there was a reported error/issue, and the details of the issue
+- if broadcast + mined: **must** see if the transaction was rejected, and why
+- if ignored: **must** be able to submit, reject or still ignore the transaction (<a name="0001-WALL-079" href="#0001-WALL-079">0001-WALL-079</a>)
 
 .. so I can find all the information about what has happened with mined and un-mined transactions
 ## Key management
 When using a Vega wallet, I...
 
 - **must** be able to create new keys (derived from the source of wallet) (<a name="0001-WALL-052" href="#0001-WALL-052">0001-WALL-052</a>)
-- **should** be prompted to give keys an alias (user can ignore) (<a name="0001-WALL-053" href="#0001-WALL-053">0001-WALL-053</a>)
+- **should** be prompted to give keys an alias (user can ignore)
 - **must** see full public key or be able to copy it to clipboard (<a name="0001-WALL-054" href="#0001-WALL-054">0001-WALL-054</a>)
 - **must** be able to change key name/alias (<a name="0001-WALL-055" href="#0001-WALL-055">0001-WALL-055</a>)
 - **must** be able to amend other arbitrary key meta data (<a name="0001-WALL-056" href="#0001-WALL-056">0001-WALL-056</a>)
@@ -171,7 +164,7 @@ When wishing to use my wallet to sign arbitrary messages, I...
 
 - **must** enter content to be signed with key  (<a name="0001-WALL-062" href="#0001-WALL-062">0001-WALL-062</a>)
 - **must** see an option to base64 encode content before signing (<a name="0001-WALL-063" href="#0001-WALL-063">0001-WALL-063</a>)
-   - **should** only have the option to broadcast valid Vega transactions to a selected network (<a name="0001-WALL-064" href="#0001-WALL-064">0001-WALL-064</a>)
+   - **should** only have the option to broadcast valid Vega transactions to a selected network
 - **must** be able to submit/sign the content and am given a hash of the signed content as well as the message (now encoded) (<a name="0001-WALL-065" href="#0001-WALL-065">0001-WALL-065</a>)
   - **must** be able to [track progress](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network) of broadcast transaction (<a name="0001-WALL-071" href="#0001-WALL-071">0001-WALL-071</a>)
 

--- a/user-interface/0002-WCON-connect_vega_wallet.md
+++ b/user-interface/0002-WCON-connect_vega_wallet.md
@@ -4,14 +4,14 @@
 
 When looking to use Vega via a user interface e.g. Dapp (Decentralized web App), I...
 
-- If the app loads and already has a connection it can restore "eagerly" (without the user having to click connect) it **could** do so (<a name="0002-WCON-041" href="#0002-WCON-041">0002-WCON-041</a>)
-- **should** see a link to get a Vega wallet (in case I don't already have one) (<a name="0002-WCON-036" href="#0002-WCON-036">0002-WCON-036</a>)
-- **should** see a link to connect that opens up connection options (<a name="0002-WCON-001" href="#0002-WCON-001">0002-WCON-001</a>)
-- **should** have a way to easily access help should I need to troubleshoot my connection e.g. link to the docs (<a name="0002-WCON-040" href="#0002-WCON-040">0002-WCON-040</a>)
+- If the app loads and already has a connection it can restore "eagerly" (without the user having to click connect) it **could** do so
+- **should** see a link to get a Vega wallet (in case I don't already have one)
+- **should** see a link to connect that opens up connection options
+- **should** have a way to easily access help should I need to troubleshoot my connection e.g. link to the docs
 - **must** select a connection method / wallet type: (<a name="0002-WCON-002" href="#0002-WCON-002">0002-WCON-002</a>)
 - if Rest:
   - **must** have the option to input a non-default Wallet location (<a name="0002-WCON-003" href="#0002-WCON-003">0002-WCON-003</a>)
-  - **should** warn if the dapp is unable the see a wallet is running at the wallet location  (<a name="0002-WCON-004" href="#0002-WCON-004">0002-WCON-004</a>)
+  - **should** warn if the dapp is unable the see a wallet is running at the wallet location
   - **must** submit attempt to connect to wallet (<a name="0002-WCON-005" href="#0002-WCON-005">0002-WCON-005</a>)
   - **could** trigger the app to open on the user's machine with a `vegawallet://` prompt
   
@@ -21,9 +21,9 @@ When looking to use Vega via a user interface e.g. Dapp (Decentralized web App),
   - if the wallet does NOT have an existing permission with the wallet: **must** prompt user to check wallet app to approve the request to connect wallet: See [Connecting to Dapps](0002-WCON-connect_vega_wallet.md#connect-wallet) for what should happen in wallet app (<a name="0002-WCON-009" href="#0002-WCON-009">0002-WCON-009</a>)
   
   - if new keys are given permission: **must** show the user the keys have been approved (<a name="0002-WCON-010" href="#0002-WCON-010">0002-WCON-010</a>)
-    - **should** see [public key(s)](DATA-data_display.md#public-keys). (<a name="0002-WCON-037" href="#0002-WCON-037">0002-WCON-037</a>)
-    - **should** see alias(es) (<a name="0002-WCON-011" href="#0002-WCON-011">0002-WCON-011</a>)
-    - **could** see assets on key(s) (<a name="0002-WCON-012" href="#0002-WCON-012">0002-WCON-012</a>)
+    - **should** see [public key(s)](DATA-data_display.md#public-keys)
+    - **should** see alias(es)
+    - **could** see assets on key(s)
     - **would like to** see positions on key(s) 
     - if the dapp uses one key at a time: **should** prompt me to select key. See [select/switch keys](#select-and-switch-keys). (<a name="0002-WCON-014" href="#0002-WCON-014">0002-WCON-014</a>)
 
@@ -52,7 +52,7 @@ When wishing to disconnect my wallet, I...
 
 - **must** see an option to disconnect wallet (<a name="0002-WCON-022" href="#0002-WCON-022">0002-WCON-022</a>)
 - **must** see confirmation that wallet has been disconnected (<a name="0002-WCON-023" href="#0002-WCON-023">0002-WCON-023</a>)
-- **should** see prompt to connect a wallet, after disconnect (<a name="0002-WCON-024" href="#0002-WCON-024">0002-WCON-024</a>)
+- **should** see prompt to connect a wallet, after disconnect
 
 ... so that I can protect my wallet from malicious use or select a different wallet to connect to
 
@@ -66,11 +66,11 @@ when looking to do something with a specific key (or set of keys) from my wallet
 
 - for each key:
   - **must** see the first and last 6 digits of the [public key](DATA-data_display.md#public-keys). (<a name="0002-WCON-027" href="#0002-WCON-027">0002-WCON-027</a>)
-  - **should** be able to see the whole public key (<a name="0002-WCON-028" href="#0002-WCON-028">0002-WCON-028</a>)
+  - **should** be able to see the whole public key
   - **must** be able to copy to clipboard the whole public key (<a name="0002-WCON-029" href="#0002-WCON-029">0002-WCON-029</a>)
   - **must** see the key name/alias (meta data) (<a name="0002-WCON-030" href="#0002-WCON-030">0002-WCON-030</a>)
-  - **should** see what non-zero assets that key has (<a name="0002-WCON-031" href="#0002-WCON-031">0002-WCON-031</a>)
-  - **could** see the total asset balances (including associated) (<a name="0002-WCON-032" href="#0002-WCON-032">0002-WCON-032</a>)
+  - **should** see what non-zero assets that key has
+  - **could** see the total asset balances (including associated)
   - **would like to see** a breakdown of the accounts. See [collateral / accounts](6001-COLL-collateral.md)
   - **would like to** see any active orders or positions. See [collateral / accounts](6001-COLL-collateral.md)
   - **would like to** see my nominations to validators for associated tokens

--- a/user-interface/0003-WTXN-submit_vega_transaction.md
+++ b/user-interface/0003-WTXN-submit_vega_transaction.md
@@ -13,18 +13,18 @@ if not connected to a Vega wallet:
 if transaction not auto approved by wallet:
 
 - **must** see a prompt to check connected vega wallet to approve transaction (<a name="0003-WTXN-002" href="#0003-WTXN-002">0003-WTXN-002</a>)
-- **could** see the transaction details that has been passed to the wallet for broadcast (<a name="0003-WTXN-019" href="#0003-WTXN-019">0003-WTXN-019</a>)
+- **could** see the transaction details that has been passed to the wallet for broadcast
 
 if transaction is approved by wallet:
 
 - **must** see A [transaction hash](DATA-data_display.md#transaction-hash) (<a name="0003-WTXN-003" href="#0003-WTXN-003">0003-WTXN-003</a>)
 - **must** see the public key that this transaction was submitted for (<a name="0003-WTXN-004" href="#0003-WTXN-004">0003-WTXN-004</a>)
-- **should** see the alias for the key that submitted this transaction (<a name="0003-WTXN-005" href="#0003-WTXN-005">0003-WTXN-005</a>)
-- **could** see a prompt to set this app to [auto approve](0001-WALL-wallet.md#approving-transactions) in wallet app (<a name="0003-WTXN-006" href="#0003-WTXN-006">0003-WTXN-006</a>)
+- **should** see the alias for the key that submitted this transaction
+- **could** see a prompt to set this app to [auto approve](0001-WALL-wallet.md#approving-transactions) in wallet app
 
 if transaction is rejected by wallet:
 
-- **must** see that the order was rejected by the connected wallet (<a name="0003-WTXN-007" href="#0003-WTXN-007">0003-WTXN-007</a>)
+- **could** see that the order was rejected by the connected wallet (closing the window automatically may be appropriate) (<a name="0003-WTXN-007" href="#0003-WTXN-007">0003-WTXN-007</a>)
 
 if the wallet does not respond:
 
@@ -33,7 +33,7 @@ if the wallet does not respond:
 if the wallet highlights an issue with the transaction:
 
 - **must** show that the transaction was marked as invalid by the wallet and not broadcast (<a name="0003-WTXN-009" href="#0003-WTXN-009">0003-WTXN-009</a>)
-- **should** see the error returned highlighted in context of the form that submitted the transaction in Dapp (<a name="0003-WTXN-010" href="#0003-WTXN-010">0003-WTXN-010</a>)
+- **should** see the error returned highlighted in context of the form that submitted the transaction in Dapp
 - **must** show error returned by wallet (<a name="0003-WTXN-011" href="#0003-WTXN-011">0003-WTXN-011</a>)
 
 ## Track transaction on network 


### PR DESCRIPTION
Things that are not musts are not a priority for testing. And may not have been agreed for implementation.

This PR removes AC codes for anything that is not a **Must**.

shoulds, could, and woulds are are still there as stretch tasks (or optional improvements) but are not expected to be implemented or have e2e tests