### PR TITLE
fix: Amend acceptance criteria for reusing proof of work details

### DIFF
--- a/protocol/0072-SPPW-spam-protection-PoW.md
+++ b/protocol/0072-SPPW-spam-protection-PoW.md
@@ -70,8 +70,8 @@ The initial hash-function used is SHA3 . To allow for a more fine-grained contro
 
 # Acceptance Criteria
 - A message with a missing/wrong PoW is rejected (<a name="0072-SPPW-001" href="#0072-SPPW-001">0072-SPPW-001</a>)
-- Reusing the same PoW for several messages is detected and leads to a blocking of the account (<a name="0072-SPPW-002" href="#0072-SPPW-002">0072-SPPW-002</a>)
+- Reusing the same PoW for several messages is detected and the messages are rejected (<a name="0072-SPPW-002" href="#0072-SPPW-002">0072-SPPW-002</a>)
 - Linking too many transactions to the same block is detected and leads to a blocking of that account (if the increasing difficulty is turned of) (<a name="0072-SPPW-003" href="#0072-SPPW-003">0072-SPPW-003</a>)
 - Linking too many transactions with a low difficulty level to a block is detected and leads to blocking of the account (if increasing difficulty is turned on) (<a name="0072-SPPW-004" href="#0072-SPPW-004">0072-SPPW-004</a>)
-- Reusing a transaction identifier in a way that dseveral transactions with the same ID end up in the same block si detected and leads to a blocking of the account (<a name="0072-SPPW-005" href="#0072-SPPW-005">0072-SPPW-005</a>)
+- Reusing a transaction identifier in a way that several transactions with the same ID end up in the same block is detected and the transactions are rejected (<a name="0072-SPPW-005" href="#0072-SPPW-005">0072-SPPW-005</a>)
 - A blocked account is unblocked after 4 epochs. (<a name="0072-SPPW-006" href="#0072-SPPW-006">0072-SPPW-006</a>)


### PR DESCRIPTION
Amend AC's for reusing proof of work details.
Transactions are now rejected rather than the parties being banned.