### PR TITLE
Add AC to the position resolution spec

### DIFF
--- a/protocol/0012-POSR-position_resolution.md
+++ b/protocol/0012-POSR-position_resolution.md
@@ -7,6 +7,7 @@ Feature name: position-resolution
 * [ ] One market order is submitted for the net liability (<a name="0012-POSR-003" href="#0012-POSR-003">0012-POSR-003</a>)
 * [ ] Mark Price is never updated during position resolution (<a name="0012-POSR-004" href="#0012-POSR-004">0012-POSR-004</a>)
 * [ ] Non-distressed traders who trade with the network because their open orders are hit during the close out trade have their positions settled correctly. (<a name="0012-POSR-005" href="#0012-POSR-005">0012-POSR-005</a>)
+* [ ] When a distressed party has a [staking account](./0013-ACCT-accounts.md) with the same currency as the settlement currency of the market where it's disstressed the staking account is NOT used in margin search and liquidation. (<a name="0012-POSR-006" href="#0012-POSR-006">0012-POSR-006</a>)
 
 # Summary
 


### PR DESCRIPTION
Add AC assuring that staking account cannot be used in the distressed flow as requested by QA. 

Closes https://github.com/vegaprotocol/specs/issues/1316