### PR TITLE
chore: clarify 0064-VALP-006

### DIFF
--- a/protocol/0064-VALP-validator_performance_based_rewards.md
+++ b/protocol/0064-VALP-validator_performance_based_rewards.md
@@ -69,8 +69,8 @@ The performance score should be available on all the same API endpoints as the `
   * Verify that at the beginning of the next epoch the validator has non 0 performance score, and voting power is greater than 10. 
   * Update the network parameter `reward.staking.delegation.minimumValidatorStake` for minimum self-stake to be more than is self-delegated. 
   * Verify that, at the beginning of the next epoch, all performance scores are 0 and voting power for all is 1 but the network keeps producing blocks and no nodes were removed from Tendermint.
- 6. Scores are produced after a snapshot restart (<a name="0064-VALP-006" href="#0064-VALP-006">0064-VALP-006</a>):  
-  * Restart network from snapshot which contains validator performance scores. After restart when network is operable, scores should be available and updated correctly to reflect current validator count.
+ 6. Scores are restored after a snapshot restart (<a name="0064-VALP-006" href="#0064-VALP-006">0064-VALP-006</a>):  
+  * With a snapshot that was taken at a block-height that falls in the middle of an epoch, restart a node from that snapshot. Ensure that at the end of the epoch the node remains in consensus and has produced the correct performance scores.
 
 
 # Future Stuff (in here for discussion purposes, not yet to be implemented)


### PR DESCRIPTION
closes #1329 

Talking about snapshots alongside whole network restarts was confusing.