### PR TITLE
fix: out of date query on add to project

### DIFF
--- a/.github/workflows/add_issue_new_projects.yml
+++ b/.github/workflows/add_issue_new_projects.yml
@@ -1,26 +1,28 @@
 ---
 
-name: Auto Assign Issue to New Project
+name: "Add Issues To Project Board"
 
 "on":
   issues:
-    types: [opened]
+    types:
+      - opened
+env:
+  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  PROJECT_ID: ${{ secrets.PROTOCOL_DESIGN_PROJECT_ID }}
+  ISSUE_ID: ${{ github.event.issue.node_id }}
+  USER: ${{ github.actor }}
 
 jobs:
   add_issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Add Issue to New Core Project Board
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
-          PROJECT_ID: ${{ secrets.PROTOCOL_DESIGN_PROJECT_ID }}
-          ISSUE_ID: ${{ github.event.issue.node_id }}
+      - name: "Add issue to project board"
         run: |
           gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID -f user=$USER

--- a/.github/workflows/add_pr_new_projects.yml
+++ b/.github/workflows/add_pr_new_projects.yml
@@ -1,26 +1,28 @@
 ---
 
-name: Auto Assign PR to New Project
+name: "Add IPRs To Project Board"
 
 "on":
-  pull_request:
-    types: [opened]
+  issues:
+    types:
+      - opened
+env:
+  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  PROJECT_ID: ${{ secrets.PROTOCOL_DESIGN_PROJECT_ID }}
+  PR_ID: ${{ github.event.pull_request.node_id }}
+  USER: ${{ github.actor }}
 
 jobs:
-  add_pr:
+  add_issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Add PR to New Core Project Board
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
-          PROJECT_ID: ${{ secrets.PROTOCOL_DESIGN_PROJECT_ID }}
-          PR_ID: ${{ github.event.pull_request.node_id }}
+      - name: "Add pr to project board"
         run: |
           gh api graphql -f query='
-            mutation($project:ID!, $pr:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $pr:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $pr}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectNextItem.projectNextItem.id'
+            }' -f project=$PROJECT_ID -f pr=$PR_ID -f user=$USER


### PR DESCRIPTION
Since Nov 1st 2022 the GutHub classic project APIs were deprecated, and no longer work with the new projects. This fix updates the queries to use the projectV2 fields.

error seen:

```
gh: Could not resolve to ProjectNext node with the global id of '***'.
{"data":{"addProjectNextItem":null},"errors":[{"type":"NOT_FOUND","path":["addProjectNextItem"],"locations":[{"line":3,"column":5}],"message":"Could not resolve to ProjectNext node with the global id of '***'."}]}
Error: Process completed with exit code 1.
```

This change should mean the actions run as expected and all items are added to the protocol design project board.