### PR TITLE
Use existing netparam for LP shape

### DIFF
--- a/protocol/0078-NWLI-network_wide_limits.md
+++ b/protocol/0078-NWLI-network_wide_limits.md
@@ -18,6 +18,7 @@ If it gets decreased below the current total number of pegged orders across all 
 ## LP order shapes
 
 Each [LP order shape](./0038-OLIQ-liquidity_provision_order_type.md#how-they-are-submitted) has a limit of entries (offsets) driven by `market.liquidityProvision.shapes.maxSize`.
+Default value: `5`.
 
 ### Change of network parameter
 

--- a/protocol/0078-NWLI-network_wide_limits.md
+++ b/protocol/0078-NWLI-network_wide_limits.md
@@ -17,7 +17,12 @@ If it gets decreased below the current total number of pegged orders across all 
 
 ## LP order shapes
 
-Each [LP order shape](./0038-OLIQ-liquidity_provision_order_type.md#how-they-are-submitted) has a hardcoded limit of at most 5 entries (offsets).
+Each [LP order shape](./0038-OLIQ-liquidity_provision_order_type.md#how-they-are-submitted) has a limit of entries (offsets) driven by `market.liquidityProvision.shapes.maxSize`.
+
+### Change of network parameter
+
+If the network parameter gets increased via a governance vote no further actions are needed.\
+If it gets decreased below the current total number of pegged orders across all active markets then no further actions are needed. Specifically: all existing LP orders remain unaffected, but any new LP orders need to respect it.
 
 ## Acceptance Criteria
 
@@ -34,3 +39,4 @@ Each [LP order shape](./0038-OLIQ-liquidity_provision_order_type.md#how-they-are
 * Submitting a [liquidity provision order](./0038-OLIQ-liquidity_provision_order_type.md) with 5 buy shapes and 5 sell shapes proceeds without any errors and liquidity provision becomes active. (<a name="0078-NWLI-005" href="#0078-NWLI-005">0078-NWLI-005</a>)
 * Submitting a liquidity provision order with 6 buy shapes and 5 sell shapes results in a failure. Error message attributes the rejection to the limit. (<a name="0078-NWLI-006" href="#0078-NWLI-006">0078-NWLI-006</a>)
 * Submitting a liquidity provision order with 5 buy shapes and 6 sell shapes results in a failure. Error message attributes the rejection to the limit. (<a name="0078-NWLI-007" href="#0078-NWLI-007">0078-NWLI-007</a>)
+* Lowering the `market.liquidityProvision.shapes.maxSize` network parameter doesn't affect the existing orders, but a new LP order that exceeds it gets rejected. (<a name="0078-NWLI-008" href="#0078-NWLI-008">0078-NWLI-008</a>)


### PR DESCRIPTION
We already have a network parameter `market.liquidityProvision.shapes.maxSize` so let's use it.