### PR TITLE
add ethereum heartbeat to performance measurement

### DIFF
--- a/protocol/0064-VALP-validator_performance_based_rewards.md
+++ b/protocol/0064-VALP-validator_performance_based_rewards.md
@@ -20,7 +20,7 @@ let `v` be the voting power of the validator in the previous epoch
 let `t` be the total voting power in the previous epoch
 
 let `expected = v*b/t` the number of blocks we expected the validator to propose. 
-Then `proposer_performance_score = max(0.05, min((p/expected, 1))`
+Then `proposer_performance_score = min(p/expected, 1)`
 
 ### Ersatz and pending validators
 For validators who [have submitted a transaction to become validators](./0069-VCBS-validators_chosen_by_stake.md) the `ersatz_performance_score` is defined as follows: during each epoch
@@ -44,7 +44,7 @@ For a given validator let
 - `e` be the expected number of events to be forwarded in a just-elapsed epoch which is `e := number of vega block in the last epoch / n`. 
 
 Each validator (consensus, ersatz, pending) is assgined a block number (call this `b`); either the genesis block or the block in which their pending transaction has been submitted. 
-Every `n+b` vega chain blocks the validator must forward a hash of an ethereum block, ethereum block time (newer than all the other submitted till now by other validators) and the ethereum chain block number via the [Ethereum event forwarder (eef)](./0036-BRIE-event_queue.md) and the other consensus validators must confirm its validity (i.e. after observing the message from the "verifying" validator they must forward the block hash for the appropriate block number). 
+Every `n+b` vega chain blocks the validator must forward a hash of an ethereum block and the ethereum chain block number  (strictly higher than all the other submitted till now by other validators) via the [Ethereum event forwarder (eef)](./0036-BRIE-event_queue.md) and the other consensus validators must confirm its validity (i.e. after observing the message from the "verifying" validator they must forward the block hash for the appropriate block number). 
 Once this becomes verified as correct (as per the voting and number of confirmation rules in [eef](./0036-BRIE-event_queue.md) spec) increment `c` by `1`. 
 
 At the end of an epoch:
@@ -54,7 +54,7 @@ At the end of an epoch:
 ## Final score 
 We need to combine PM1 and PM2 into a final score. To that end for each tendermint consensus validator set 
 ```
-performance_score <- proposer_performance_score x eefScore
+performance_score <- max(0.05, proposer_performance_score x eefScore)
 ```
 and for pending / ersatz validators set
 ```


### PR DESCRIPTION
At the moment validators with mis-cofigured / missing ethereum forwarding get same performance rewards as everyone else. 

But not verifying Ethereum events has terrible consequences (deposits / staking) won't work. So it needs to be taken into account. 

close https://github.com/vegaprotocol/specs/issues/1993