### PR TITLE
fix: duplicate AC code in spec

### DIFF
--- a/protocol/0057-TRAN-transfers.md
+++ b/protocol/0057-TRAN-transfers.md
@@ -277,7 +277,7 @@ A user's recurring transfer to a reward account does not occur if there are no p
   - At the end of the third epoch, no transfer occurs
 
 If the network parameter <transfer.minTransferFeeFactor> is modified, this modification is applied
-immediately, i.e., transfers are accepted/rejected according to the new parameter. This holds for both increase and decrease. (<a name="0057-TRAN-059" href="#0057-TRAN-059">0057-TRAN-059</a>)
+immediately, i.e., transfers are accepted/rejected according to the new parameter. This holds for both increase and decrease. (<a name="0057-TRAN-062" href="#0057-TRAN-062">0057-TRAN-062</a>)
 
 If the network parameter <spam.protection.maxUserTransfersPerEpoch> is modified, this modification is applied from the next Epoch on, i.e., transfers are accepted/rejected according to the new parameter. This holds for both increase and decrease. (<a name="0057-TRAN-060" href="#0057-TRAN-060">0057-TRAN-060</a>)
 


### PR DESCRIPTION
Fixed the duplicate 0057-TRAN-059 in the spec relating to issues 

- https://github.com/vegaprotocol/system-tests/issues/1584
- https://github.com/vegaprotocol/system-tests/issues/1571