### PR TITLE
Round liquidity score to 10 dp

### DIFF
--- a/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md
+++ b/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md
@@ -170,6 +170,8 @@ Then on every Vega time change, after `fractional instantenous liquidity score` 
 liquidity score <- ((n-1)/n) x liquidity score + (1/n) x fractional instantenous liquidity score
 ```
 
+The liquidity score should always be rounded to 10 decimal places to prevent spurious accuracy and overly long string representation of a number.
+
 ### Distributing fees
 
 On every trade, liquidity fee should be collected immediately into an account for each liquidity provider (call it LP fee account). Each party will have an LP fee account on every market on which they committed liquidity by providing LP stake. 


### PR DESCRIPTION
This was done: https://github.com/vegaprotocol/vega/pull/7200

to prevent that:
<img width="1734" alt="image (1)" src="https://user-images.githubusercontent.com/9922111/209104864-961ec60a-d6f1-4810-910d-be4e86a241ed.png">

so let's bring spec in line with it. 