### PR TITLE
User interface: always show rejected reason if there is one

### DIFF
--- a/user-interface/7002-SORD-submit_orders.md
+++ b/user-interface/7002-SORD-submit_orders.md
@@ -162,7 +162,6 @@ When populating a deal ticket I...
 - All feedback must be a subscription so is updated as the status changes (<a name="7002-SORD-053" href="#7002-SORD-053">7002-SORD-053</a>)
  - **could** repeat the values that were submitted (order type + all fields)
 
-
 ... so that I am aware of the status of my order before seeing it in the [orders table](6002-MORD-manage_orders.md).
 
 ... so I get the sort of order, and price, I wish.

--- a/user-interface/7002-SORD-submit_orders.md
+++ b/user-interface/7002-SORD-submit_orders.md
@@ -158,8 +158,10 @@ When populating a deal ticket I...
   - Filled. Must be able to see/link to all trades that were created from this order. (<a name="7002-SORD-046" href="#7002-SORD-046">7002-SORD-046</a>)
   - Rejected: **must** see the reason it was rejected (<a name="7002-SORD-047" href="#7002-SORD-047">7002-SORD-047</a>)
   - Parked: **must** see an explanation of why parked orders happen (<a name="7002-SORD-048" href="#7002-SORD-048">7002-SORD-048</a>)
+  - All: **must** see a rejected reason if one was provided (<a name="7002-SORD-067" href="#7002-SORD-067">7002-SORD-067</a>)
 - All feedback must be a subscription so is updated as the status changes (<a name="7002-SORD-053" href="#7002-SORD-053">7002-SORD-053</a>)
  - **could** repeat the values that were submitted (order type + all fields)
+
 
 ... so that I am aware of the status of my order before seeing it in the [orders table](6002-MORD-manage_orders.md).
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -54,6 +54,7 @@ When looking at a list of orders, I...
 - if order created by [pegged or liquidity provision shape](9001-DATA-data_display.md#order-origin): **should** see order origin
   - **could** see what part of the liquidity shape or pegged order shape this relates to or it's offset+reference See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
   - **could** see link to full shape
+- if the order has a rejected reason: **must** see the rejected reason  (<a name="7003-MORD-018" href="#7003-MORD-018">7003-MORD-018</a>)
 
 - **should** see how much of the order's [size](9001-DATA-data_display.md#size) has been filled e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
 - **should** see how much of the order's [size](9001-DATA-data_display.md#size) remains. 


### PR DESCRIPTION
Adds AC so that we test whether a rejected reason is shown, having learned that the rejection reason can be populated even when a order does not have the status of `rejected`