### PR TITLE
fix: duplicated AC code in SPAM spec

### DIFF
--- a/protocol/0062-SPAM-spam_protection.md
+++ b/protocol/0062-SPAM-spam_protection.md
@@ -122,7 +122,7 @@ Any withdrawal requests for a smaller amounts are immediately rejected.
  - Any rejection due to spam protection is reported to the user upon transaction submission detailing which criteria the key exceeded / not met  (<a name="0062-SPAM-013" href="#0062-SPAM-013">0062-SPAM-013</a>)  
  - If a party is banned for too many voting-rejections, it still can send trading related transactions which are not banned. (<a name="0062-SPAM-025" href="#0062-SPAM-025">0062-SPAM-025</a>)  
  - If the ban of a party ends because the banning time is up, transactions from that party are no longer rejected (<a name="0062-SPAM-015" href="#0062-SPAM-015">0062-SPAM-015</a>)  
- - If the ban of a party ends because the epoch ends, transactions from that party are no longer rejected (<a name="0062-SPAM-016" href="#0062-SPAM-016">0062-SPAM-063</a>)  
+ - If the ban of a party ends because the epoch ends, transactions from that party are no longer rejected (<a name="0062-SPAM-016" href="#0062-SPAM-016">0062-SPAM-016</a>)  
  - If a party gets banned, the ban ends due to the epoch ending, and it gets banned again at the beginning of the new epoch, the ban still lasts the entire time (or until the next epoch end), i.e., the ban-expiration timer is reset. (<a name="0062-SPAM-017" href="#0062-SPAM-017">0062-SPAM-017</a>)  
  - If a party gets banned several times during an epoch, all banns last for the defined time or until the epoch ends (try with at least three banns) (<a name="0062-SPAM-018" href="#0062-SPAM-018">0062-SPAM-018</a>)  
  - During a ban due to too many votes, all governance related transactions are rejected (<a name="0062-SPAM-019" href="#0062-SPAM-019">0062-SPAM-019</a>)  

--- a/protocol/0062-SPAM-spam_protection.md
+++ b/protocol/0062-SPAM-spam_protection.md
@@ -120,7 +120,7 @@ Any withdrawal requests for a smaller amounts are immediately rejected.
  - It is possible for spam transactions to fill a block (<a name="0062-SPAM-010" href="#0062-SPAM-010">0062-SPAM-010</a>)
  - Parties that continue spamming are blocked and eventually unblocked again  (<a name="0062-SPAM-011" href="#0062-SPAM-011">0062-SPAM-011</a>)
  - Any rejection due to spam protection is reported to the user upon transaction submission detailing which criteria the key exceeded / not met  (<a name="0062-SPAM-013" href="#0062-SPAM-013">0062-SPAM-013</a>)  
- - If a party is banned for too many voting-rejections, it still can send trading related transactions which are not banned. (<a name="0062-SPAM-014" href="#0062-SPAM-014">0062-SPAM-013</a>)  
+ - If a party is banned for too many voting-rejections, it still can send trading related transactions which are not banned. (<a name="0062-SPAM-025" href="#0062-SPAM-025">0062-SPAM-025</a>)  
  - If the ban of a party ends because the banning time is up, transactions from that party are no longer rejected (<a name="0062-SPAM-015" href="#0062-SPAM-015">0062-SPAM-015</a>)  
  - If the ban of a party ends because the epoch ends, transactions from that party are no longer rejected (<a name="0062-SPAM-016" href="#0062-SPAM-016">0062-SPAM-063</a>)  
  - If a party gets banned, the ban ends due to the epoch ending, and it gets banned again at the beginning of the new epoch, the ban still lasts the entire time (or until the next epoch end), i.e., the ban-expiration timer is reset. (<a name="0062-SPAM-017" href="#0062-SPAM-017">0062-SPAM-017</a>)  


### PR DESCRIPTION
Running the extended approbation checks I have noticed duplicate AC codes in the SPAM spec


Related QA task:
- https://github.com/vegaprotocol/system-tests/issues/1640#issuecomment-1380023949