### PR TITLE
chore: Remove untestable acceptance criteria - 0076-DANO-018

### DIFF
--- a/protocol/0076-DANO-data-node.md
+++ b/protocol/0076-DANO-data-node.md
@@ -188,6 +188,5 @@ It must be possible to add to the data node APIs that return the result of calcu
 1. The DataNode must be able to handle brief network outages and disconnects from the vega node (<a name="0076-DANO-015" href="#0076-DANO-015">0076-DANO-015</a>)
 1. The validator node will only accept requests for event bus subscriptions. All other API subscription requests will be invalid. (<a name="0076-DANO-016" href="#0076-DANO-016">0076-DANO-016</a>)
 1. The event bus stream is available from validators, non validators and the DataNode (<a name="0076-DANO-017" href="#0076-DANO-017">0076-DANO-017</a>)
-1. All events that are emitted on the full unfiltered event stream are processed by the DataNode (no data is lost) (<a name="0076-DANO-018" href="#0076-DANO-018">0076-DANO-018</a>)
 1. If a DataNode loses connection to a Vega node if will attempt to reconnect and if the cached data received from the Vega node is enough to continue working it can resume being a DataNode. (<a name="0076-DANO-019" href="#0076-DANO-019">0076-DANO-019</a>)
 1. The DataNode must provide its current block height and vega time on responses to client requests so the client can determine whether or not the data is stale. (<a name="0076-DANO-021" href="#0076-DANO-021">0076-DANO-021</a>)


### PR DESCRIPTION
Removing AC 0076-DANO-018 as per the comments below:

`TBH that sounds like a criteria that is easy to write but pretty intense to implement without basically reimplementing the datanode in python in the system tests :slightly_smiling_face: I guess you might have have to have some sort of big switch statement that looks at each event that was emitted, and then does some API call to check that the right stuff got put in the DB`

**Slack thread on this discussion for reference:**
https://vegaprotocol.slack.com/archives/C02KVKMAE82/p1675873898560439

