### PR TITLE
user interface: Wallet: Remove requirement codes for things that have not been implemented

### DIFF
--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -55,11 +55,11 @@ When using a given wallet, I...
 When a dapp requests use of a wallet, I...
 
 - **must** be prompted to either select a wallet or dismiss the prompt  (<a name="0001-WALL-017" href="#0001-WALL-017">0001-WALL-017</a>)
-- **must** select what keys of a wallet to grant access to (<a name="0001-WALL-018" href="#0001-WALL-018">0001-WALL-018</a>)
+- **should** select what keys of a wallet to grant access to
   - **must** be able to select whole wallet (so that new keys are automatically shared) (<a name="0001-WALL-019" href="#0001-WALL-019">0001-WALL-019</a>)
-  - `TODO:` **must** be able to select specific [keys](DATA-data_display.md#public-keys) (<a name="0001-WALL-020" href="#0001-WALL-020">0001-WALL-020</a>)
-  - tainted keys **must** be shown as tainted (<a name="0001-WALL-021" href="#0001-WALL-021">0001-WALL-021</a>)
-  - tainted keys **must** not be selectable (<a name="0001-WALL-073" href="#0001-WALL-073">0001-WALL-073</a>)
+  - **should** be able to select specific [keys](DATA-data_display.md#public-keys)
+  - tainted keys **should** be shown as tainted
+  - tainted keys **should** not be selectable 
 - **must** enter wallet passphrase before wallet details are shared (assuming a password has not recently been entered)(<a name="0001-WALL-022" href="#0001-WALL-022">0001-WALL-022</a>)
 - **must** be able to retrospectively revoke Dapp's access to a Wallet (<a name="0001-WALL-023" href="#0001-WALL-023">0001-WALL-023</a>)
 - **must** be able to retrospectively revoke Dapp's access particular keys in a wallet (<a name="0001-WALL-072" href="#0001-WALL-072">0001-WALL-072</a>)

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -3,7 +3,7 @@ A Vega wallet is required to prepare and submit transaction on Vega  (place, can
 
 A wallet can contain many public/private key pairs. The public part of each key pair is known the [Party](../protocol/0017-PART-party.md) sometimes just referred to as a key or public key. 
 
-The primary job(s) of a wallet app is to [sign/encrypt transaction](../protocol/0022-AUTH-auth.md) (so the network can be sure they were sent by a given party) and to broadcast these transactions to a node on the network.
+The primary job(s) of a wallet is to [sign/encrypt transaction](../protocol/0022-AUTH-auth.md) (so the network can be sure they were sent by a given party) and to broadcast these transactions to a node on the network.
 
 ## Get wallet
 When on the wallet page of Vega.xyz, I...
@@ -12,12 +12,12 @@ When on the wallet page of Vega.xyz, I...
 - **must** see a download link for the various operating systems (<a name="0001-WALL-002" href="#0001-WALL-002">0001-WALL-002</a>)
 - **must** be able to use the default wallet version linked/downloadable from this page with the version of Vega currently running on mainnet (<a name="0001-WALL-076" href="#0001-WALL-076">0001-WALL-076</a>)
 
-...so I can download and run the wallet app on my machine and use it to interact with the Vega mainnet
+...so I can download and run a wallet on my machine and use it to interact with the Vega mainnet
 
 ## Set up wallet / Restore wallet
 When opening the wallet for the first time, I...
 
-- if the app sends telemetry/analytics: **must** be prompted to opt into (or stay out of) analytics (<a name="0001-WALL-003" href="#0001-WALL-003">0001-WALL-003</a>)
+- if the wallet sends telemetry/analytics: **must** be prompted to opt into (or stay out of) analytics (<a name="0001-WALL-003" href="#0001-WALL-003">0001-WALL-003</a>)
 - **must** be able to restore a wallet from a seed phrase (<a name="0001-WALL-004" href="#0001-WALL-004">0001-WALL-004</a>)
 - **must** be able to create a new wallet (<a name="0001-WALL-005" href="#0001-WALL-005">0001-WALL-005</a>)
   - **must** be shown the back up phrase (<a name="0001-WALL-006" href="#0001-WALL-006">0001-WALL-006</a>)
@@ -34,7 +34,7 @@ When using the wallet on a network, I...
 - **must** be able refine the configuration for existing networks (including the ones that come pre-configured) (<a name="0001-WALL-011" href="#0001-WALL-011">0001-WALL-011</a>)
 - **must** be able to remove networks (<a name="0001-WALL-013" href="#0001-WALL-013">0001-WALL-013</a>)
 
-...so I can broadcast transactions to, and read information from a vega network in my wallet app
+...so I can broadcast transactions to, and read information from a vega network in my wallet
 
 ## Update wallet
 When using an older version of a Vega wallet than the current official release, I...
@@ -91,7 +91,7 @@ When looking for a specific balance or asset on a given wallet and network, I...
 ## Transactions
 When thinking about a recent or specific transaction, I ...
 
-- **must** see a history of transactions the wallet app has signed. As read from the local app (Current "session" only, as persistent data storage has other requirements (see commented out ACs)) (<a name="0001-WALL-034" href="#0001-WALL-034">0001-WALL-034</a>)
+- **must** see a history of transactions the wallet has signed. As read from the local app (Current "session" only, as persistent data storage has other requirements (see commented out ACs)) (<a name="0001-WALL-034" href="#0001-WALL-034">0001-WALL-034</a>)
 - **could** see a history of transactions the selected key has broadcast to a network (e.g. another wallet with the same keys), or from before a key restore
 - **must** see pending transactions (Transactions I have not yet approved/rejected) (<a name="0001-WALL-035" href="#0001-WALL-035">0001-WALL-035</a>)
 - **must** see transactions that have recently been broadcast but not yet seen on the chain (<a name="0001-WALL-036" href="#0001-WALL-036">0001-WALL-036</a>)
@@ -107,7 +107,7 @@ when looking at a specific transaction...
 - **must** see the time request to sign and send was made (<a name="0001-WALL-040" href="#0001-WALL-040">0001-WALL-040</a>)
 - **should** see the referrer that made the request (with note that this is not verified)
 - **must** see what wallet / key is being used (<a name="0001-WALL-042" href="#0001-WALL-042">0001-WALL-042</a>)
-- **should** be able to select auto approve for this app (aka don't ask me again)
+- **should** be able to select auto approve for this dApp (aka don't ask me again)
   - **should** be able to select to auto approve for a amount of time that I choose
   - **should** be able to select to auto approve for a number of transaction that I choose 
 - **must** be prompted to enter passphrase (when needed to sign + broadcast transaction) (<a name="0001-WALL-044" href="#0001-WALL-044">0001-WALL-044</a>)
@@ -180,6 +180,3 @@ When seeking to reduce risk of compromise I...
 - `TODO:` **should** be able to link some wallets to specific networks
 
 ... so that I must administrate my wallets
-
-## App settings (Not sure if this needs AC?)
-- TODO Link or lock a key to a given network

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -8,9 +8,9 @@ The primary job(s) of a wallet is to [sign/encrypt transaction](../protocol/0022
 ## Get wallet
 When on the wallet page of Vega.xyz, I...
 
-- **must** see links to the latest version of all the available wallets (e.g. desktop, command line and browser plugin) (inc github repos) (<a name="0001-WALL-001" href="#0001-WALL-001">0001-WALL-001</a>)
-- **must** see a download link for the various operating systems (<a name="0001-WALL-002" href="#0001-WALL-002">0001-WALL-002</a>)
-- **must** be able to use the default wallet version linked/downloadable from this page with the version of Vega currently running on mainnet (<a name="0001-WALL-076" href="#0001-WALL-076">0001-WALL-076</a>)
+- **should** see links to the latest version of all the available wallets (e.g. desktop, command line and browser plugin) (inc github repos) 
+- **should** see a download link for the various operating systems 
+- **should** be able to use the default wallet version linked/downloadable from this page with the version of Vega currently running on mainnet
 
 ...so I can download and run a wallet on my machine and use it to interact with the Vega mainnet
 
@@ -39,7 +39,7 @@ When using the wallet on a network, I...
 ## Update wallet
 When using an older version of a Vega wallet than the current official release, I...
 
-- **must** be prompted to download a newer major release version, and given a link to get latest on github (<a name="0001-WALL-014" href="#0001-WALL-014">0001-WALL-014</a>)
+- **must** be prompted to download a newer major release version, and given a link to get latest on github 
 - **must** be warned if the version I am using is not compatible with the version of Vega on the selected network, and I am given a link to get latest compatible version on github (<a name="0001-WALL-015" href="#0001-WALL-015">0001-WALL-015</a>)
 
 ... so the version of the wallet app I am using works with the network I am using
@@ -94,7 +94,7 @@ When thinking about a recent or specific transaction, I ...
 - **must** see a history of transactions the wallet has signed. As read from the local app (Current "session" only, as persistent data storage has other requirements (see commented out ACs)) (<a name="0001-WALL-034" href="#0001-WALL-034">0001-WALL-034</a>)
 - **could** see a history of transactions the selected key has broadcast to a network (e.g. another wallet with the same keys), or from before a key restore
 - **must** see pending transactions (Transactions I have not yet confirmed/rejected) (<a name="0001-WALL-035" href="#0001-WALL-035">0001-WALL-035</a>)
-- **must** see transactions that have recently been broadcast but not yet seen on the chain (<a name="0001-WALL-036" href="#0001-WALL-036">0001-WALL-036</a>)
+- **should** see transactions that have recently been broadcast but not yet seen on the chain 
 - **must** see transactions that were rejected by the wallet user (me) (<a name="0001-WALL-037" href="#0001-WALL-037">0001-WALL-037</a>)
 - (for tainted keys) **should** see attempts to use a tainted key (these did not prompt the user, but allows a user to change permissions) (<a name="0001-WALL-038" href="#0001-WALL-038">0001-WALL-038</a>)
 
@@ -103,22 +103,22 @@ When thinking about a recent or specific transaction, I ...
 ## Transaction detail
 when looking at a specific transaction...
 
-- **must** see the content of the transaction decoded (<a name="0001-WALL-039" href="#0001-WALL-039">0001-WALL-039</a>)
-- **must** see the time request to sign and send was made (<a name="0001-WALL-040" href="#0001-WALL-040">0001-WALL-040</a>)
+- **should** see the content of the transaction decoded
+- **should** see the time request to sign and send was made
 - **should** see the referrer that made the request (with note that this is not verified)
-- **must** see what wallet / key is being used (<a name="0001-WALL-042" href="#0001-WALL-042">0001-WALL-042</a>)
+- **should** see what wallet / key is being used 
 - **should** be able to select auto-confirm for this dApp (aka don't ask me again) (aka automatic consent)
   - **should** be able to select to auto-confirm for a amount of time that I choose
   - **should** be able to select to auto-confirm for a number of transaction that I choose 
-- **must** be prompted to enter passphrase (when needed to sign + broadcast transaction) (<a name="0001-WALL-044" href="#0001-WALL-044">0001-WALL-044</a>)
-- **must** see [status of broadcasted transactions](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network). (<a name="0001-WALL-045" href="#0001-WALL-045">0001-WALL-045</a>)
-- **must** be able to follow a link to block explorer for broadcasted transactions (<a name="0001-WALL-046" href="#0001-WALL-046">0001-WALL-046</a>)
+- **should** be prompted to enter passphrase (when needed to sign + broadcast transaction)
+- **should** see [status of broadcasted transactions](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network)
+- **should** be able to follow a link to block explorer for broadcasted transactions 
 - if broadcast: **should** see what node it was broadcast to
 - if broadcast + mined: **could** see what validator mined the block the transaction was included in
-- if broadcast + mined: **must** see at what block and time it was confirmed (<a name="0001-WALL-049" href="#0001-WALL-049">0001-WALL-049</a>)
-- if broadcast but there was an error: **must** see if there was a reported error/issue, and the details of the issue
+- if broadcast + mined: **should** see at what block and time it was confirmed 
+- if broadcast but there was an error: **should** see if there was a reported error/issue, and the details of the issue
 - if broadcast + mined: **must** see if the transaction was rejected, and why
-- if ignored: **must** be able to submit, reject or still ignore the transaction (<a name="0001-WALL-079" href="#0001-WALL-079">0001-WALL-079</a>)
+- if ignored: **should** be able to submit, reject or still ignore the transaction 
 
 .. so I can find all the information about what has happened with mined and un-mined transactions
 ## Key management

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -165,7 +165,7 @@ When wishing to use my wallet to sign arbitrary messages, I...
 - **must** enter content to be signed with key  (<a name="0001-WALL-062" href="#0001-WALL-062">0001-WALL-062</a>)
    - **should** only have the option to broadcast valid Vega transactions to a selected network
 - **must** be able to submit/sign the content and am given a hash of the signed content as well as the message (now encoded) (<a name="0001-WALL-065" href="#0001-WALL-065">0001-WALL-065</a>)
-  - **must** be able to [track progress](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network) of broadcast transaction (<a name="0001-WALL-071" href="#0001-WALL-071">0001-WALL-071</a>)
+  - **must** be able to [track progress](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network) of broadcast transaction either by being given a hash that I can use in block explorer, or see the transaction status (<a name="0001-WALL-071" href="#0001-WALL-071">0001-WALL-071</a>)
 
 .. so I can control of the message being signed, and can use the message elsewhere (for example to prove I own a wallet)
 

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -163,7 +163,6 @@ When I want to create an extra level of security for a given key, I...
 When wishing to use my wallet to sign arbitrary messages, I...
 
 - **must** enter content to be signed with key  (<a name="0001-WALL-062" href="#0001-WALL-062">0001-WALL-062</a>)
-- **must** see an option to base64 encode content before signing (<a name="0001-WALL-063" href="#0001-WALL-063">0001-WALL-063</a>)
    - **should** only have the option to broadcast valid Vega transactions to a selected network
 - **must** be able to submit/sign the content and am given a hash of the signed content as well as the message (now encoded) (<a name="0001-WALL-065" href="#0001-WALL-065">0001-WALL-065</a>)
   - **must** be able to [track progress](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network) of broadcast transaction (<a name="0001-WALL-071" href="#0001-WALL-071">0001-WALL-071</a>)

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -164,7 +164,7 @@ When wishing to use my wallet to sign arbitrary messages, I...
 
 - **must** enter content to be signed with key  (<a name="0001-WALL-062" href="#0001-WALL-062">0001-WALL-062</a>)
    - **should** only have the option to broadcast valid Vega transactions to a selected network
-- **must** be able to submit/sign the content and am given a hash of the signed content as well as the message (now encoded) (<a name="0001-WALL-065" href="#0001-WALL-065">0001-WALL-065</a>)
+- **must** be able to submit/sign the content (<a name="0001-WALL-065" href="#0001-WALL-065">0001-WALL-065</a>)
   - **must** be able to [track progress](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network) of broadcast transaction either by being given a hash that I can use in block explorer, or see the transaction status (<a name="0001-WALL-071" href="#0001-WALL-071">0001-WALL-071</a>)
 
 .. so I can control of the message being signed, and can use the message elsewhere (for example to prove I own a wallet)
@@ -176,7 +176,7 @@ When seeking to reduce risk of compromise I...
 - **must** be able to switch between wallets (<a name="0001-WALL-067" href="#0001-WALL-067">0001-WALL-067</a>)
 - **must** be able to remove a wallet (<a name="0001-WALL-068" href="#0001-WALL-068">0001-WALL-068</a>)
 - **must** be able to change wallet name (<a name="0001-WALL-069" href="#0001-WALL-069">0001-WALL-069</a>)
-- **must** be able to change wallet passphrase (<a name="0001-WALL-070" href="#0001-WALL-070">0001-WALL-070</a>)
+- **should** be able to change wallet passphrase
 - `TODO:` **should** be able to link some wallets to specific networks
 
 ... so that I must administrate my wallets

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -78,13 +78,13 @@ When a dapp sends a transaction to the wallet for signing and broadcast, I...
 ## View keys balances + positions/accounts
 When looking for a specific balance or asset on a given wallet and network, I...
 
-- **must** see total balances of an asset for each key (<a name="0001-WALL-027" href="#0001-WALL-027">0001-WALL-027</a>)
+- **should** see total balances of an asset for each key
 - **should** see a breakdown of all accounts for an asset on a key
 - **should** see a summary of balances when switching keys
 - **would like to** be able to search by market name/code, and see all keys with a margin or liquidity account in matching markets
 - **should** be able to search by asset name or code, and see all keys with balance of matching assets
 - **should** be able to search for arbitrary metadata added by user to keys
-- **must** be able to see a total of all asset for all keys in a given wallet (<a name="0001-WALL-033" href="#0001-WALL-033">0001-WALL-033</a>)
+- **should** be able to see a total of all asset for all keys in a given wallet
  
 ... so that I can find the keys that I am looking for, see how much I have to consolidate (via transfers) or withdraw funds
 

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -9,7 +9,7 @@ The primary job(s) of a wallet app is to [sign/encrypt transaction](../protocol/
 When on the wallet page of Vega.xyz, I...
 
 - **must** see links to the latest version of all the available wallets (e.g. desktop, command line and browser plugin) (inc github repos) (<a name="0001-WALL-001" href="#0001-WALL-001">0001-WALL-001</a>)
-- **must** see a primary download button is configured for the latest version and the operating system I am using. With a link to download for other operating systems too (<a name="0001-WALL-002" href="#0001-WALL-002">0001-WALL-002</a>)
+- **must** see a download link for the various operating systems (<a name="0001-WALL-002" href="#0001-WALL-002">0001-WALL-002</a>)
 - **must** be able to use the default wallet version linked/downloadable from this page with the version of Vega currently running on mainnet (<a name="0001-WALL-076" href="#0001-WALL-076">0001-WALL-076</a>)
 
 ...so I can download and run the wallet app on my machine and use it to interact with the Vega mainnet

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -69,9 +69,9 @@ When a dapp requests use of a wallet, I...
 ## Approving transactions
 When a dapp sends a transaction to the wallet for signing and broadcast, I...
 
-- **must** be prompted to approve, reject or ignore the transaction (if auto approve is not on) (<a name="0001-WALL-024" href="#0001-WALL-024">0001-WALL-024</a>)
+- **must** be prompted to confirm, reject or ignore the transaction (if auto-confirm is not on) (<a name="0001-WALL-024" href="#0001-WALL-024">0001-WALL-024</a>)
 - **must** see the details of the transaction. See [details of transaction](#transaction-detail). (<a name="0001-WALL-025" href="#0001-WALL-025">0001-WALL-025</a>)
-- **must** see any ignored/dismissed in a transactions area along with pending, approved and rejected transactions (e.g. history). See [Transactions](#transactions).
+- **must** see any ignored/dismissed in a transactions area along with pending, confirmed/sent and rejected transactions (e.g. history). See [Transactions](#transactions).
 
 ... so I can verify that the transaction being sent is the one I want
 
@@ -93,7 +93,7 @@ When thinking about a recent or specific transaction, I ...
 
 - **must** see a history of transactions the wallet has signed. As read from the local app (Current "session" only, as persistent data storage has other requirements (see commented out ACs)) (<a name="0001-WALL-034" href="#0001-WALL-034">0001-WALL-034</a>)
 - **could** see a history of transactions the selected key has broadcast to a network (e.g. another wallet with the same keys), or from before a key restore
-- **must** see pending transactions (Transactions I have not yet approved/rejected) (<a name="0001-WALL-035" href="#0001-WALL-035">0001-WALL-035</a>)
+- **must** see pending transactions (Transactions I have not yet confirmed/rejected) (<a name="0001-WALL-035" href="#0001-WALL-035">0001-WALL-035</a>)
 - **must** see transactions that have recently been broadcast but not yet seen on the chain (<a name="0001-WALL-036" href="#0001-WALL-036">0001-WALL-036</a>)
 - **must** see transactions that were rejected by the wallet user (me) (<a name="0001-WALL-037" href="#0001-WALL-037">0001-WALL-037</a>)
 - (for tainted keys) **should** see attempts to use a tainted key (these did not prompt the user, but allows a user to change permissions) (<a name="0001-WALL-038" href="#0001-WALL-038">0001-WALL-038</a>)
@@ -107,9 +107,9 @@ when looking at a specific transaction...
 - **must** see the time request to sign and send was made (<a name="0001-WALL-040" href="#0001-WALL-040">0001-WALL-040</a>)
 - **should** see the referrer that made the request (with note that this is not verified)
 - **must** see what wallet / key is being used (<a name="0001-WALL-042" href="#0001-WALL-042">0001-WALL-042</a>)
-- **should** be able to select auto approve for this dApp (aka don't ask me again)
-  - **should** be able to select to auto approve for a amount of time that I choose
-  - **should** be able to select to auto approve for a number of transaction that I choose 
+- **should** be able to select auto-confirm for this dApp (aka don't ask me again) (aka automatic consent)
+  - **should** be able to select to auto-confirm for a amount of time that I choose
+  - **should** be able to select to auto-confirm for a number of transaction that I choose 
 - **must** be prompted to enter passphrase (when needed to sign + broadcast transaction) (<a name="0001-WALL-044" href="#0001-WALL-044">0001-WALL-044</a>)
 - **must** see [status of broadcasted transactions](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network). (<a name="0001-WALL-045" href="#0001-WALL-045">0001-WALL-045</a>)
 - **must** be able to follow a link to block explorer for broadcasted transactions (<a name="0001-WALL-046" href="#0001-WALL-046">0001-WALL-046</a>)

--- a/user-interface/0001-WALL-wallet.md
+++ b/user-interface/0001-WALL-wallet.md
@@ -165,7 +165,7 @@ When wishing to use my wallet to sign arbitrary messages, I...
 - **must** enter content to be signed with key  (<a name="0001-WALL-062" href="#0001-WALL-062">0001-WALL-062</a>)
    - **should** only have the option to broadcast valid Vega transactions to a selected network
 - **must** be able to submit/sign the content (<a name="0001-WALL-065" href="#0001-WALL-065">0001-WALL-065</a>)
-  - **must** be able to [track progress](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network) of broadcast transaction either by being given a hash that I can use in block explorer, or see the transaction status (<a name="0001-WALL-071" href="#0001-WALL-071">0001-WALL-071</a>)
+  - **should** be able to [track progress](0003-WTXN-submit_vega_transaction.md#track-transaction-on-network) of broadcast transaction either by being given a hash that I can use in block explorer, or see the transaction status
 
 .. so I can control of the message being signed, and can use the message elsewhere (for example to prove I own a wallet)
 


### PR DESCRIPTION
following https://vegaprotocol.slack.com/archives/C04P12ZBS02/p1676382105097109

This Removes some AC codes for features that have been chosen not to implement so we don't need to test.

- showing asset balances in the wallet
- not able to change wallet password
- no ability to broadcast arbitrary message from DT wallet
- auto-confirmation
- selecting only the keys you want to share with a dApp
- Getting alerts for new versions of the app
- Broadcasting any arbitrary message to a node

Removes an AC that was a misunderstanding 

- base64 encoding of messages used to be required for signing up to incentives

Moved ACs currently meet though the website (about getting a wallet)

- there are now no tests to ensure sending people to Vega.xyz/wallet helps them

Calrifies what is meant by tracking a transaction. Getting a hash is enough. (although a link to Block explorer would be bring it up to par with how most other wallets behave)