### PR TITLE
SLA liquidity (extras)

### DIFF
--- a/glossaries/trading-and-protocol-glossary.md
+++ b/glossaries/trading-and-protocol-glossary.md
@@ -185,7 +185,7 @@ The net riskiest composition of a trader's open positions and live orders.  For 
 
 ### Liquidity Providers
 
-Liquidity providers commit a bond and place a special Liquidity Commitment that automatically maintains orders on the book for a specific market. In return, liquidity providers earn a [fee](#fees) for ensuring that markets always have open volume. See [the liquidity provision spec](./../protocol/0044-LIME-lp_mechanics.md) for more detail.
+Liquidity providers commit a bond which specifies their SLA obligations. In return for meeting these the liquidity providers earn a portion of the trading [fees](#fees) from the market in which they operate. See [the liquidity provision spec](./../protocol/0044-LIME-lp_mechanics.md) for more detail.
 
 ## M
 

--- a/protocol/0013-ACCT-accounts.md
+++ b/protocol/0013-ACCT-accounts.md
@@ -73,7 +73,7 @@ If there is a positive balance in an account that is being deleted, that balance
 
 ## Bond accounts
 
-Bond accounts are opened when a party opens a [Liquidity Provision order](./0038-OLIQ-liquidity_provision_order_type.md). The bond is held by the network to ensure that the Liquidity PRovider maintains enough collateral to cover their commitment. [0044-LIME - LP Mechanics](./0044-LIME-lp_mechanics.md) contains more detail on bond management.
+Bond accounts are opened when a party opens a [Liquidity Provision order](./0038-OLIQ-liquidity_provision_order_type.md). The bond is held by the network to ensure that the Liquidity Provider meets their SLA obligations. [0044-LIME - LP Mechanics](./0044-LIME-lp_mechanics.md) contains more detail on bond management.
 
 ## Insurance pools
 

--- a/protocol/0014-ORDT-order_types.md
+++ b/protocol/0014-ORDT-order_types.md
@@ -210,6 +210,7 @@ Network orders are used during [position resolution](./0012-POSR-position_resolu
   * Any GTT limit order that [still] resides on the order book at its expiry time is cancelled and removed from the book before any events are processed that rely on its being present on the book, including any calculation that incorporates its volume and/or price level. (<a name="0014-ORDT-004" href="#0014-ORDT-004">0014-ORDT-004</a>)
   * A GTT order submitted at a time >= its expiry time is rejected. (<a name="0014-ORDT-005" href="#0014-ORDT-005">0014-ORDT-005</a>)
 * No party can submit a [network order type](#network-orders)  (<a name="0014-ORDT-006" href="#0014-ORDT-006">0014-ORDT-006</a>)
+* A pegged order (including iceberg pegged orders) never has it's price updated during the execution of an incoming aggressive order (even as price levels get consummed so that it's reference price changes after the execution). (<a name="0014-ORDT-039" href="#0014-ORDT-039">0014-ORDT-039</a>)
 
 ### Iceberg Orders AC's
 

--- a/protocol/0014-ORDT-order_types.md
+++ b/protocol/0014-ORDT-order_types.md
@@ -210,7 +210,7 @@ Network orders are used during [position resolution](./0012-POSR-position_resolu
   * Any GTT limit order that [still] resides on the order book at its expiry time is cancelled and removed from the book before any events are processed that rely on its being present on the book, including any calculation that incorporates its volume and/or price level. (<a name="0014-ORDT-004" href="#0014-ORDT-004">0014-ORDT-004</a>)
   * A GTT order submitted at a time >= its expiry time is rejected. (<a name="0014-ORDT-005" href="#0014-ORDT-005">0014-ORDT-005</a>)
 * No party can submit a [network order type](#network-orders)  (<a name="0014-ORDT-006" href="#0014-ORDT-006">0014-ORDT-006</a>)
-* A pegged order (including iceberg pegged orders) never has it's price updated during the execution of an incoming aggressive order (even as price levels get consummed so that it's reference price changes after the execution). (<a name="0014-ORDT-039" href="#0014-ORDT-039">0014-ORDT-039</a>)
+* A pegged order (including iceberg pegged orders) never has its price updated during the execution of an incoming aggressive order (even as price levels get consummed so that its reference price changes after the execution). (<a name="0014-ORDT-039" href="#0014-ORDT-039">0014-ORDT-039</a>)
 
 ### Iceberg Orders AC's
 

--- a/protocol/0039-MKTD-market_depth_calculation.md
+++ b/protocol/0039-MKTD-market_depth_calculation.md
@@ -15,8 +15,6 @@
 - Market depth will show a crossed book if the market is in auction and the book is crossed (<a name="0039-MKTD-013" href="#0039-MKTD-013">0039-MKTD-013</a>)
 - Leaving an auction will cause any GFA orders to be removed from the market depth view (<a name="0039-MKTD-014" href="#0039-MKTD-014">0039-MKTD-014</a>)
 - Pegged orders are part of the market depth view and should update the view when their orders are repriced (<a name="0039-MKTD-015" href="#0039-MKTD-015">0039-MKTD-015</a>)
-- Liquidity orders are part of the market depth view and should update the view when commitment sizes change (<a name="0039-MKTD-016" href="#0039-MKTD-016">0039-MKTD-016</a>)
-- Liquidity orders are part of the market depth view and should update the view when their reference prices move (<a name="0039-MKTD-017" href="#0039-MKTD-017">0039-MKTD-017</a>)
 - Each delta update will have the new sequence number along with the previous sequence number which will match the previous delta update (<a name="0039-MKTD-018" href="#0039-MKTD-018">0039-MKTD-018</a>)
 - The sequence number received as part of the market depth snapshot will match the sequence number of a delta update (<a name="0039-MKTD-019" href="#0039-MKTD-019">0039-MKTD-019</a>)
 

--- a/protocol/0041-TSTK-target_stake.md
+++ b/protocol/0041-TSTK-target_stake.md
@@ -93,7 +93,7 @@ Then: the target stake value is
     target_stake = 0.25 * 11000 = 2750 DAI
 ```
 
-The above design ensures the `target_stake` of a market is unable to fluctuate dramatically over the window. Controlling the `target_stake` indirectly controls the `total_stake` as the amount an LP is able to reduce their commitment is restricted by the `maximum_reduction_amount`.
+The above design ensures the `target_stake` of a market is unable to fluctuate dramatically over the window. Controlling the `target_stake` impacts the `total_stake` as reducing the commitment beyond `maximum_reduction_amount` means the LPs will be charged a penalty for doing so.
 
 ### Acceptance criteria
 

--- a/protocol/0044-LIME-lp_mechanics.md
+++ b/protocol/0044-LIME-lp_mechanics.md
@@ -105,7 +105,7 @@ The amendment is actioned in two steps.
 1) the amount is immediately transferred from the party's general account to a temporary "pending" bond account. This amount counts towards the stake committed to the market and so in particular can get the market out of liquidity auction.
 2) at the beginning of the next epoch (after the rewards / penalties for present LPs - including the party that's amending - have been evaluated) the amount is transferred from the "pending" bond to the true bond account.
 
-For each party only the most recent amendement should be considered. All the amendements get processed simultaneously, hence the relative arrival of amendments made by different LPs within the previous epoch is irrelevant.
+For each party only the most recent amendement should be considered. All the amendements get processed simultaneously, hence the relative arrival of amendments made by different LPs within the previous epoch is irrelevant (as far as commitment reduction is concerned, it still has implications for other aspects of the mechanism).
 
 #### Increasing commitment
 

--- a/user-interface/7003-MORD-manage_orders.md
+++ b/user-interface/7003-MORD-manage_orders.md
@@ -4,7 +4,7 @@ Users place orders to describe the trades they would like to make: buy or sell, 
 
 Once a user has placed an order they may wish to confirm it's [status](https://docs.vega.xyz/docs/mainnet/graphql/enums/order-status) in a [list](#orders-list) of other orders. e.g. whether it has been accepted, filled, how close it is to being filled etc. Users may be interested in the price of their orders relative to the price of the market and how much of the order's size has been filled.
 
-Orders can also be placed on behalf of a user/party via [liquidity](#liquidity-order-shapes) or [pegged](#pegged-order-shapes) order shapes. These order cannot be amended on canceled in the same way as other orders.
+Orders can also be placed on behalf of a user/party via [pegged](#pegged-orders) orders.
 
 Markets also have [statuses](https://docs.vega.xyz/docs/mainnet/graphql/enums/market-state) that may affect how a user perceives the state of an order, e.g if the order was placed while in "normal" continuous trading, but the market is now in auction. 
 
@@ -53,9 +53,8 @@ When looking at a list of orders, I...
 - **must** see the [size](9001-DATA-data_display.md#size) of the order (<a name="7003-MORD-003" href="#7003-MORD-003">7003-MORD-003</a>)
 - **must** see the [direction/side](9001-DATA-data_display.md#direction--side) (Long or Short) of the order (this can be implied with a + or negative suffix on the size, + for Long, - for short) (<a name="7003-MORD-004" href="#7003-MORD-004">7003-MORD-004</a>)
 - **must** see [order type](9001-DATA-data_display.md#order-type) (<a name="7003-MORD-005" href="#7003-MORD-005">7003-MORD-005</a>)
-- if order created by [pegged or liquidity provision shape](9001-DATA-data_display.md#order-origin): **should** see order origin
-  - **could** see what part of the liquidity shape or pegged order shape this relates to or it's offset+reference See [pegged orders](#pegged-order-shapes) and [liquidity provisions](#liquidity-order-shapes) shapes below.
-  - **could** see link to full shape
+- if order created by [a pegged order](9001-DATA-data_display.md#order-origin): **should** see order origin
+  - **could** see it's offset+reference. See [pegged orders](#pegged-order-shapes),
 
 - **should** see how much of the order's [size](9001-DATA-data_display.md#size) has been filled e.g. if the order was for `50` but so far only 10 have traded I should see Filled = `10`. Note: this is marked as a should because in the case of Rejected order and some other scenarios it isn't relevant.
 - **should** see how much of the order's [size](9001-DATA-data_display.md#size) remains. 
@@ -70,12 +69,12 @@ When looking at a list of orders, I...
 
 - **should** see time priority (how many orders are before mine at this price)
   
-- if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [amend](#amend-order---price) the individual order (<a name="7003-MORD-007" href="#7003-MORD-007">7003-MORD-007</a>)
-- if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to amend the individual order (<a name="7003-MORD-008" href="#7003-MORD-008">7003-MORD-008</a>)
-  - **could** see a link to amend shape
-- if the order is `Active` &amp; **not** part of a liquidity or peg shape: **must** see an option to [cancel](#cancel-orders) the individual order
-- if the order is `Active` &amp; is part of a liquidity or peg shape: **must** **not** see an option to cancel the individual order
-  - **could** see a link to cancel shape
+- if the order is `Active` &amp; **not** a pegged order: **must** see an option to [amend](#amend-order---price) the individual order (<a name="7003-MORD-007" href="#7003-MORD-007">7003-MORD-007</a>)
+- if the order is `Active` &amp; is a pegged order: **must** **not** see an option to amend the resulting active order at the current price (<a name="7003-MORD-008" href="#7003-MORD-008">7003-MORD-008</a>)
+  - **could** see a link to amend the pegged order itself
+- if the order is `Active` &amp; **not** a pegged order: **must** see an option to [cancel](#cancel-orders) the individual order
+- if the order is `Active` &amp; is a pegged order **must** **not** see an option to cancel the individual order
+  - **could** see a link to cancel the pegged order
 
 ... so I can understand the state of my orders and decide what to do next
 ### Filters
@@ -164,42 +163,20 @@ when looking at an order book, I...
 
 ... so I can see my orders in context of price history
 
-## Pegged order shapes
+## Pegged orders
 
-When looking to understand the state of a pegged order shape...
+When looking to understand the state of a pegged order...
 
-- **should** see the whole shape of a pegged order
 - **must** see the reference, offset and direction for each part pegged order (<a name="7003-MORD-016" href="#7003-MORD-016">7003-MORD-016</a>)
 - **should** see the current price for each buy/sell
 - **should** see the filled/remaining for each part of the order
 - when order is not `Active`: **should** show the order status (perhaps instead of price)
-- **should** be able to cancel the whole pegged order
+- **should** be able to cancel the pegged order
 - **would** like to see link to edit the shape of a pegged order
 - **would** like to see the date submitted/updated
 
-... so I can decide if I wish to amend or cancel my pegged order shape
+... so I can decide if I wish to amend or cancel my pegged order
 
-## Cancel Pegged order shapes
+## Cancel Pegged order
 
 `TODO`
-
-## Liquidity order shapes
-
-When looking to understand the state of a liquidity provision, with a provided shape... 
-
-- **would** like to see the liquidity commitment order status (`pending`, `active`, `parked`, `canceled` etc)
-- **would** like to see the fee bid
-
-- **should** see the whole shape of a liquidity order
-- **must** see the reference, offset and direction for each part liquidity order order (<a name="7003-MORD-017" href="#7003-MORD-017">7003-MORD-017</a>)
-- **should** see the current price for each buy/sell
-- when order is not `Active`: **should** show the order status (perhaps instead of price)
-- **should** see link to cancel the whole liquidity order shape (see [liquidity provision](5002-LIQP-provide_liquidity.md))
-- **would** like to see link to edit the shape of a pegged order (see [liquidity provision](5002-LIQP-provide_liquidity.md))
-- **would** like to see the date submitted/updated
-
-... so I can decide if I wish to amend or cancel my shape
-
-## Cancel or amend Pegged order shapes
-
-See [liquidity provision](5002-LIQP-provide_liquidity.md),


### PR DESCRIPTION
A PR to merge additional items into the original `feat/sla-liquidity` branch, including:

* extend description of the liquidity provider temporary bond account and specify that any search attempting to access the true bond account should first go via this account,
* the LPs commitment level is always equal to the balance of their "true" bond account,
* we should never try to automatically top up any of the bond accounts from general,
* LP amendments should all be processed at the beginning of the epoch and each LP's penalty free amount should be calculated pro rata based on the size of the reduction. 