### PR TITLE
chore: add missing iceberg AC code

### DIFF
--- a/protocol/0014-ORDT-order_types.md
+++ b/protocol/0014-ORDT-order_types.md
@@ -271,7 +271,7 @@ Network orders are used during [position resolution](./0012-POSR-position_resolu
 ### API
 
 1. API end points should be available to query initial peak size, minimum peak size, quantity, displayed quantity and remaining (<a name="0014-ORDT-036" href="#0014-ORDT-036">0014-ORDT-036</a>)
-2. The additional fields relating to iceberg orders should be available in the streaming api end points
+2. The additional fields relating to iceberg orders should be available in the streaming api end points (<a name="0014-ORDT-040" href="#0014-ORDT-040">0014-ORDT-040</a>)
 
 ### See also
 


### PR DESCRIPTION
Adds a missing AC code to critera for iceberg APIs