### PR TITLE
Fix/ditch temp bond acct

### DIFF
--- a/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md
+++ b/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md
@@ -51,7 +51,7 @@ In the example below there are 3 liquidity providers all bidding for their chose
 
 ### Timing market's liquidity-fee-factor changes
 
-Once the market opens (opening auction starts) a clock starts ticking. We calculate the `[target stake]` using [target stake](./0041-TSTK-target_stake.md). The fee is re-evaluated using the mechanism above at the start of each epoch using LPs commitments at start of epoch. 
+Once the market opens (opening auction starts) a clock starts ticking. We calculate the `[target stake]` using [target stake](./0041-TSTK-target_stake.md). The fee is re-evaluated using the mechanism above at the start of each epoch using LPs commitments at start of epoch.
 
 ### APIs for fee factor calculations - what should core be exposing?
 

--- a/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md
+++ b/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md
@@ -51,7 +51,7 @@ In the example below there are 3 liquidity providers all bidding for their chose
 
 ### Timing market's liquidity-fee-factor changes
 
-Once the market opens (opening auction starts) a clock starts ticking. We calculate the `[target stake]` using [target stake](./0041-TSTK-target_stake.md). The fee is continuously re-evaluated using the mechanism above.
+Once the market opens (opening auction starts) a clock starts ticking. We calculate the `[target stake]` using [target stake](./0041-TSTK-target_stake.md). The fee is re-evaluated using the mechanism above at the start of each epoch using LPs commitments at start of epoch. 
 
 ### APIs for fee factor calculations - what should core be exposing?
 

--- a/protocol/0044-LIME-lp_mechanics.md
+++ b/protocol/0044-LIME-lp_mechanics.md
@@ -100,12 +100,12 @@ A participant may apply to amend their commitment amount by submitting a transac
 
 `proposed-commitment-variation = new-proposed-commitment-amount - old-commitment-amount`
 
-An increase in amendment is actioned immediately but only has implications for rewards / penalties at start of the current epoch. 
+An increase in amendment is actioned immediately but only has implications for rewards / penalties at start of the current epoch.
 
 1) the amount is immediately transferred from the party's general account to their bond account. However we keep track of commitment at start of epoch and this is used for penalties / rewards.
-2) at the beginning of the next epoch, the rewards / penalties for present LPs - including the party that's amending - are evaluated based on balance of bond account at start of epoch. 
+2) at the beginning of the next epoch, the rewards / penalties for present LPs - including the party that's amending - are evaluated based on balance of bond account at start of epoch.
 
-A decrease in commitment is noted but the transfer out of the bond account is only actioned at the end of the current epoch. 
+A decrease in commitment is noted but the transfer out of the bond account is only actioned at the end of the current epoch.
 
 For each party only the most recent amendment should be considered. All the amendments get processed simultaneously, hence the relative arrival of amendments made by different LPs within the previous epoch is irrelevant (as far as commitment reduction is concerned, it still has implications for other aspects of the mechanism).
 
@@ -215,7 +215,7 @@ Note: we don't evaluate whether LPs meet the SLA during opening auctions so ther
 
 ### Penalty for not meeting the SLA
 
-See the [Calculating the SLA performance penalty for a single epoch section in 0042-LIQF](./0042-LIQF-setting_fees_and_rewarding_lps.md) for how `fraction_of_time_on_book` is calculated. 
+See the [Calculating the SLA performance penalty for a single epoch section in 0042-LIQF](./0042-LIQF-setting_fees_and_rewarding_lps.md) for how `fraction_of_time_on_book` is calculated.
 This is available at the end of each epoch.
 If, at the end of the epoch, `fraction_of_time_on_book >= market.liquidity.committmentMinTimeFraction` then let $f=0$.
 Otherwise we calculate a penalty to be applied to the bond as follows.
@@ -239,7 +239,7 @@ Moreover, as this reduced the LP stake, update the ELS as per [Calculating liqui
 
 ### Penalty for not supporting open positions
 
-If at any point in time, a liquidity provider has insufficient capital to make the transfers for their mark to market or other settlement movements, and/or margin requirements arising from their orders and open positions, the network will utilise their liquidity provision commitment, held in the _liquidity provider bond account_ to cover the shortfall. 
+If at any point in time, a liquidity provider has insufficient capital to make the transfers for their mark to market or other settlement movements, and/or margin requirements arising from their orders and open positions, the network will utilise their liquidity provision commitment, held in the _liquidity provider bond account_ to cover the shortfall.
 The protocol will also apply a penalty proportional to the size of the shortfall, which will be transferred to the market's insurance pool.
 
 Calculating the penalty:
@@ -261,7 +261,7 @@ The network will:
 
 1. Initiate closeout of the LPs order and/or positions as normal if their margin does not meet the minimum maintenance margin level required. (NB: this should involve no change)
 
-1. _The liquidity provider's bond account balance is always their current commitment level:_ This is strictly their "true" bond account. 
+1. _The liquidity provider's bond account balance is always their current commitment level:_ This is strictly their "true" bond account.
 
 Note:
 

--- a/protocol/0044-LIME-lp_mechanics.md
+++ b/protocol/0044-LIME-lp_mechanics.md
@@ -100,10 +100,12 @@ A participant may apply to amend their commitment amount by submitting a transac
 
 `proposed-commitment-variation = new-proposed-commitment-amount - old-commitment-amount`
 
-The amendment is actioned in two steps.
+An increase in amendment is actioned immediately but only has implications for rewards / penalties at start of the current epoch. 
 
-1) the amount is immediately transferred from the party's general account to a temporary "pending" bond account. This amount counts towards the stake committed to the market and so in particular can get the market out of liquidity auction.
-2) at the beginning of the next epoch (after the rewards / penalties for present LPs - including the party that's amending - have been evaluated) the amount is transferred from the "pending" bond to the true bond account.
+1) the amount is immediately transferred from the party's general account to their bond account. However we keep track of commitment at start of epoch and this is used for penalties / rewards.
+2) at the beginning of the next epoch, the rewards / penalties for present LPs - including the party that's amending - are evaluated based on balance of bond account at start of epoch. 
+
+A decrease in commitment is noted but the transfer out of the bond account is only actioned at the end of the current epoch. 
 
 For each party only the most recent amendment should be considered. All the amendments get processed simultaneously, hence the relative arrival of amendments made by different LPs within the previous epoch is irrelevant (as far as commitment reduction is concerned, it still has implications for other aspects of the mechanism).
 

--- a/protocol/0044-LIME-lp_mechanics.md
+++ b/protocol/0044-LIME-lp_mechanics.md
@@ -169,14 +169,14 @@ The [liquidity_fee](./0029-FEES-fees.md) of a market on Vega takes as an input, 
 
 ### Distributing fees between liquidity providers
 
-When calculating fees for a trade, the size of a liquidity provider’s commitment along with when they committed and the market size are inputs that will be used to calculate how the liquidity fee is distributed between liquidity providers. See [setting fees and rewarding lps](./0042-LIQF-setting_fees_and_rewarding_lps.md) for the calculation of the split.
+When calculating fees for a trade, the size of a liquidity provider’s commitment at the start of the epoch along with when they committed and the market size are inputs that will be used to calculate how the liquidity fee is distributed between liquidity providers. See [setting fees and rewarding lps](./0042-LIQF-setting_fees_and_rewarding_lps.md) for the calculation of the split.
 
 
 ## Liquidity provision and penalties
 
 ### Calculating liquidity from commitment
 
-Committed Liquidity Providers are required to provide a multiple of their stake (supplied in the settlement currency of the market) in notional volume of orders within the range defined below on both sides of the order book.
+Committed Liquidity Providers are required to provide a multiple of their stake, at the start of the epoch, (supplied in the settlement currency of the market) in notional volume of orders within the range defined below on both sides of the order book.
 
 The multiple is controlled by a network parameter `market.liquidity.stakeToCcyVolume`:
 
@@ -213,7 +213,7 @@ Note: we don't evaluate whether LPs meet the SLA during opening auctions so ther
 
 ### Penalty for not meeting the SLA
 
-See the [Calculating the SLA performance penalty for a single epoch section in 0042-LIQF](./0042-LIQF-setting_fees_and_rewarding_lps.md) for how `fraction_of_time_on_book` is calculated.
+See the [Calculating the SLA performance penalty for a single epoch section in 0042-LIQF](./0042-LIQF-setting_fees_and_rewarding_lps.md) for how `fraction_of_time_on_book` is calculated. 
 This is available at the end of each epoch.
 If, at the end of the epoch, `fraction_of_time_on_book >= market.liquidity.committmentMinTimeFraction` then let $f=0$.
 Otherwise we calculate a penalty to be applied to the bond as follows.
@@ -237,7 +237,8 @@ Moreover, as this reduced the LP stake, update the ELS as per [Calculating liqui
 
 ### Penalty for not supporting open positions
 
-If at any point in time, a liquidity provider has insufficient capital to make the transfers for their mark to market or other settlement movements, and/or margin requirements arising from their orders and open positions, the network will utilise their liquidity provision commitment, held in the _temporary liquidity provider bond account_ and the _liquidity provider bond account_ (accessed in that order) to cover the shortfall. The protocol will also apply a penalty proportional to the size of the shortfall, which will be transferred to the market's insurance pool.
+If at any point in time, a liquidity provider has insufficient capital to make the transfers for their mark to market or other settlement movements, and/or margin requirements arising from their orders and open positions, the network will utilise their liquidity provision commitment, held in the _liquidity provider bond account_ to cover the shortfall. 
+The protocol will also apply a penalty proportional to the size of the shortfall, which will be transferred to the market's insurance pool.
 
 Calculating the penalty:
 
@@ -252,13 +253,13 @@ _Auctions:_ if this occurs at the transition from auction mode to continuous tra
 
 The network will:
 
-1. _As part of the normal collateral "search" process:_ Access first the liquidity provider's temporary bond and then (if needed) the actual bond account to make up the shortfall. If there is insufficient funds to cover this amount, the full balance of both bond accounts will be used. Note that this means that the transfer request should include the liquidity provider's temporary bond account and true bond account in the list of accounts to search, and that these accounts would always be emptied before any insurance pool funds are used or loss socialisation occurs.
+1. _As part of the normal collateral "search" process:_ Access first the liquidity provider's bond account to make up the shortfall. If there is insufficient funds to cover this amount, the full balance of both bond accounts will be used. Note that this means that the transfer request should include the liquidity provider's bond account in the list of accounts to search, and that these accounts would always be emptied before any insurance pool funds are used or loss socialisation occurs.
 
-1. _If there was a shortfall and either of the bond accounts was accessed:_ Transfer an amount equal to the `market.liquidity.bondPenaltyParameter` calculated above from the liquidity provider's bond account to the market's insurance pool. If there are insufficient funds in the temporary bond account and the bond account, the full amount will be used and the remainder of the penalty (or as much as possible) should be transferred from the liquidity provider's margin account.
+1. _If there was a shortfall and the bond account was accessed:_ Transfer an amount equal to the `market.liquidity.bondPenaltyParameter` calculated above from the liquidity provider's bond account to the market's insurance pool. If there are insufficient funds in the bond account and the bond account, the full amount will be used and the remainder of the penalty (or as much as possible) should be transferred from the liquidity provider's margin account.
 
 1. Initiate closeout of the LPs order and/or positions as normal if their margin does not meet the minimum maintenance margin level required. (NB: this should involve no change)
 
-1. _The liquidity provider's bond account balance is always their current commitment level:_ This is strictly their "true" bond account, funds in the "temporary" bond account are not counted as their commitment (though they do get included in market's overall commitment). Since we always search the temporary bond account first their true bond account balance can only drop to zero once the temporary account has already been drained. Once the party's "true" bond account balance drops to zero they are no longer a liquidity provider for fee/reward purposes. (From a Core perspective, it is as if the liquidity provider has exited their commitment entirely and they no longer need to be tracked as an LP.)
+1. _The liquidity provider's bond account balance is always their current commitment level:_ This is strictly their "true" bond account. 
 
 Note:
 
@@ -267,7 +268,7 @@ Note:
 
 ## What data do we keep relating to liquidity provision?
 
-1. List of all liquidity providers and their commitment sizes, their “equity-like share” and "liquidity score" for each market [see 0042-setting-fees-and-rewarding-lps](./0042-LIQF-setting_fees_and_rewarding_lps.md)
+1. List of all liquidity providers and their commitment sizes (bond account balance), the commitment at the start of epoch, their “equity-like share” and "liquidity score" for each market [see 0042-setting-fees-and-rewarding-lps](./0042-LIQF-setting_fees_and_rewarding_lps.md)
 1. Two new accounts (temporary bond account and bond account) per LP per market
 1. Actual amount of liquidity supplied (can be calculated from order book, [see 0034-prob-weighted-liquidity-measure](./0034-PROB-prob_weighted_liquidity_measure.ipynb))
 

--- a/protocol/0044-LIME-lp_mechanics.md
+++ b/protocol/0044-LIME-lp_mechanics.md
@@ -271,13 +271,13 @@ Note:
 ## What data do we keep relating to liquidity provision?
 
 1. List of all liquidity providers and their commitment sizes (bond account balance), the commitment at the start of epoch, their “equity-like share” and "liquidity score" for each market [see 0042-setting-fees-and-rewarding-lps](./0042-LIQF-setting_fees_and_rewarding_lps.md)
-1. Two new accounts (temporary bond account and bond account) per LP per market
+1. New bond account per LP per market
 1. Actual amount of liquidity supplied (can be calculated from order book, [see 0034-prob-weighted-liquidity-measure](./0034-PROB-prob_weighted_liquidity_measure.ipynb))
 
 
 ## APIs
 
-- Transfers to and from the temporary bond account and the true bond account, new or changed commitments, and any penalties applied should all be published on the event stream
+- Transfers to and from the bond account, new or changed commitments, and any penalties applied should all be published on the event stream
 - It should be possible to query all details of liquidity providers via an API
 
 ## Acceptance Criteria


### PR DESCRIPTION
To make core more streamlined at @karlem 's request we ditch the temporary bond account. 

Instead, keep track of bond balance at start of epoch and use this for calculating penalties and rewards at the end of epoch. And increases of the bond account balance requested by the lp go in their bond account immediately, withdrawals still at the end of epoch. 