### PR TITLE
chore: tidy up spec feature heading text

### DIFF
--- a/protocol/0028-GOVE-governance.md
+++ b/protocol/0028-GOVE-governance.md
@@ -265,7 +265,7 @@ Enactment of an asset modification proposal is:
 - For data that must be synchronised with the asset blockchain (e.g. Ethereum): _only_ the emission of a signed bundle that can be submitted to the bridge contract; the changed values [asset framework spec](./0040-ASSF-asset_framework.md) only become reflected on the Vega chain once the usual number of confirmations of the effect of this change is emitted by the bridge chain.
 - For any data that is stored only on the Vega chain: the data is updated once the proposal is enacted.
 
-## 5. Transfers initiated by Governance (post Oregon trail)
+## 5. Transfers initiated by Governance
 
 ### Permitted source and destination account types
 


### PR DESCRIPTION
The feature header here mentioned that it was "post Oregon Trail". Now we have the master and feature (milestone) branches this is no longer required and clutters the real information.