### PR TITLE
feat: use ghcr image to run approbation

### DIFF
--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -68,8 +68,8 @@ jobs:
 
       - name: "Run Check AC codes"
         run: |
-          docker run -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-filenames --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"
+          docker run -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-codes --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"
 
       - name: "Run Check file names"
         run: |
-          docker run -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-codes --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"
+          docker run -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-filenames --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"

--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -59,10 +59,17 @@ jobs:
       - name: "Check out"
         uses: actions/checkout@v3
 
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Run Check AC codes"
         run: |
-          npx github:vegaprotocol/approbation check-codes --specs="{./non-protocol-specs/**/*.md,./protocol/**/*.md}"
+          docker run -it -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-filenames --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"
 
       - name: "Run Check file names"
         run: |
-          npx github:vegaprotocol/approbation check-filenames --specs="{./non-protocol-specs/**/*.md,./protocol/**/*.md}"
+          docker run -it -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-codes --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"

--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -68,8 +68,8 @@ jobs:
 
       - name: "Run Check AC codes"
         run: |
-          docker run -it -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-filenames --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"
+          docker run -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-filenames --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"
 
       - name: "Run Check file names"
         run: |
-          docker run -it -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-codes --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"
+          docker run -v $PWD:/workspace ghcr.io/vegaprotocol/approbation:main check-codes --specs="{/workspace/non-protocol-specs/**/*.md,/workspace/protocol/**/*.md}"


### PR DESCRIPTION
The approbation run on the specs repo CI is failing:

- https://github.com/vegaprotocol/specs/actions/workflows/quality_check.yml

All failing with the same error:
```npm WARN exec The following package was not found and will be installed: github:vegaprotocol/approbation
Error: Process completed with exit code 1.```
