### PR TITLE
fix: penalty division by zero

### DIFF
--- a/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md
+++ b/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md
@@ -256,9 +256,10 @@ Let $s$ be `market.liquidity.commitmentMinTimeFraction`.
 
 Let $c$ be `market.liquidity.slaCompetitionFactor`.
 
-$$
-p_i = (1 - \frac{t - s}{1 - s}) \cdot c.
-$$
+$$p_i = \begin{cases}
+    (1 - \frac{t - s}{1 - s}) \cdot c &\text{if } s < 1 \\
+    0 &\text{if } s = 1
+\end{cases}$$
 
 #### Calculating the SLA performance penalty for over hysteresis period
 


### PR DESCRIPTION
Small spec clarification to avoid division by zero error in the case `t=s=1`