### PR TITLE
Fix example in 0083-RFPR-on_chain_referral_program.md

### DIFF
--- a/protocol/0083-RFPR-on_chain_referral_program.md
+++ b/protocol/0083-RFPR-on_chain_referral_program.md
@@ -60,7 +60,7 @@ message UpdateReferralProgram{
         benefit_tiers: [
             {
                 "minimum_running_notional_taker_volume": 10000,
-                "minimum_epochs": 0,
+                "minimum_epochs": 1,
                 "referral_reward_factor": 0.001,
                 "referral_discount_factor": 0.001,
             },


### PR DESCRIPTION
From the same docs:
> all `minimum_epochs` values must be an integer strictly greater than 0