### PR TITLE
Fix perp ac and formatting

### DIFF
--- a/protocol/0053-PERP-product_builtin_perpetual_future.md
+++ b/protocol/0053-PERP-product_builtin_perpetual_future.md
@@ -324,7 +324,7 @@ $\text{external TWAP}=\frac{11\cdot(1-0)+9\cdot(3-1)+10\cdot(5-3)+11\cdot(8-7)+8
 
 When $\text{clamp_lower_bound}=\text{clamp_upper_bound}=0$, $\text{scaling factor}=2.5$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.025$. (<a name="0053-PERP-029" href="#0053-PERP-029">0053-PERP-029</a>)
 
-When $\text{clamp_lower_bound}=\text{clamp_upper_bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.015$, $\text{rate_upper_bound}=0.005$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.015$. (<a name="0053-PERP-030" href="#0053-PERP-030">0053-PERP-030</a>)
+When $\text{clamp_lower_bound}=\text{clamp_upper_bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.005$, $\text{rate_upper_bound}=0.015$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.005$. (<a name="0053-PERP-030" href="#0053-PERP-030">0053-PERP-030</a>)
 
 When $\text{clamp_lower_bound}=\text{clamp_upper_bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.015$, $\text{rate_upper_bound}=0.005$ and the funding period ends with $\text{internal TWAP}=101$, $\text{external TWAP} = 100$ then the resulting funding rate equals $0.005$. (<a name="0053-PERP-031" href="#0053-PERP-031">0053-PERP-031</a>)
 

--- a/protocol/0053-PERP-product_builtin_perpetual_future.md
+++ b/protocol/0053-PERP-product_builtin_perpetual_future.md
@@ -322,11 +322,11 @@ Then, taking the auction into account we get:
 $\text{internal TWAP}= \frac{10\cdot(1-0)+11\cdot(3-1)+11\cdot(5-3)+9\cdot(8-7)+8\cdot(10-8)+30\cdot(10-10)}{8}=9.875$,
 $\text{external TWAP}=\frac{11\cdot(1-0)+9\cdot(3-1)+10\cdot(5-3)+11\cdot(8-7)+8\cdot(9-8)+14\cdot(10-9)}{8}=10.25$. (<a name="0053-PERP-028" href="#0053-PERP-028">0053-PERP-028</a>)
 
-When $\text{clamp_lower_bound}=\text{clamp_upper_bound}=0$, $\text{scaling factor}=2.5$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.025$. (<a name="0053-PERP-029" href="#0053-PERP-029">0053-PERP-029</a>)
+When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=2.5$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.025$. (<a name="0053-PERP-029" href="#0053-PERP-029">0053-PERP-029</a>)
 
-When $\text{clamp_lower_bound}=\text{clamp_upper_bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.005$, $\text{rate_upper_bound}=0.015$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.005$. (<a name="0053-PERP-030" href="#0053-PERP-030">0053-PERP-030</a>)
+When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.005$, $\text{rate upper_bound}=0.015$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.005$. (<a name="0053-PERP-030" href="#0053-PERP-030">0053-PERP-030</a>)
 
-When $\text{clamp_lower_bound}=\text{clamp_upper_bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.015$, $\text{rate_upper_bound}=0.005$ and the funding period ends with $\text{internal TWAP}=101$, $\text{external TWAP} = 100$ then the resulting funding rate equals $0.005$. (<a name="0053-PERP-031" href="#0053-PERP-031">0053-PERP-031</a>)
+When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=1$, $\text{rate lower bound}=-0.015$, $\text{rate upper bound}=0.005$ and the funding period ends with $\text{internal TWAP}=101$, $\text{external TWAP} = 100$ then the resulting funding rate equals $0.005$. (<a name="0053-PERP-031" href="#0053-PERP-031">0053-PERP-031</a>)
 
 When migrating the market existing prior to introduction of the additional parameters their values get set to:
 

--- a/protocol/0053-PERP-product_builtin_perpetual_future.md
+++ b/protocol/0053-PERP-product_builtin_perpetual_future.md
@@ -324,7 +324,7 @@ $\text{external TWAP}=\frac{11\cdot(1-0)+9\cdot(3-1)+10\cdot(5-3)+11\cdot(8-7)+8
 
 When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=2.5$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.025$. (<a name="0053-PERP-029" href="#0053-PERP-029">0053-PERP-029</a>)
 
-When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.005$, $\text{rate upper bound}=0.015$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.005$. (<a name="0053-PERP-030" href="#0053-PERP-030">0053-PERP-030</a>)
+When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=1$, $\text{rate lower bound}=-0.005$, $\text{rate upper bound}=0.015$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.005$. (<a name="0053-PERP-030" href="#0053-PERP-030">0053-PERP-030</a>)
 
 When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=1$, $\text{rate lower bound}=-0.015$, $\text{rate upper bound}=0.005$ and the funding period ends with $\text{internal TWAP}=101$, $\text{external TWAP} = 100$ then the resulting funding rate equals $0.005$. (<a name="0053-PERP-031" href="#0053-PERP-031">0053-PERP-031</a>)
 

--- a/protocol/0053-PERP-product_builtin_perpetual_future.md
+++ b/protocol/0053-PERP-product_builtin_perpetual_future.md
@@ -324,7 +324,7 @@ $\text{external TWAP}=\frac{11\cdot(1-0)+9\cdot(3-1)+10\cdot(5-3)+11\cdot(8-7)+8
 
 When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=2.5$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.025$. (<a name="0053-PERP-029" href="#0053-PERP-029">0053-PERP-029</a>)
 
-When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.005$, $\text{rate upper_bound}=0.015$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.005$. (<a name="0053-PERP-030" href="#0053-PERP-030">0053-PERP-030</a>)
+When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=1$, $\text{rate_lower_bound}=-0.005$, $\text{rate upper bound}=0.015$ and the funding period ends with $\text{internal TWAP}=99$, $\text{external TWAP} = 100$ then the resulting funding rate equals $-0.005$. (<a name="0053-PERP-030" href="#0053-PERP-030">0053-PERP-030</a>)
 
 When $\text{clamp lower bound}=\text{clamp upper bound}=0$, $\text{scaling factor}=1$, $\text{rate lower bound}=-0.015$, $\text{rate upper bound}=0.005$ and the funding period ends with $\text{internal TWAP}=101$, $\text{external TWAP} = 100$ then the resulting funding rate equals $0.005$. (<a name="0053-PERP-031" href="#0053-PERP-031">0053-PERP-031</a>)
 


### PR DESCRIPTION
For AC `0053-PERP-030` we set an internal TWAP of 99 and an external of 100 which naturally creates a funding rate of `-0.01`, but we then set a lower bound of `-0.015` and expect the funding rate to be snapped to it, which isn't right?

I've changed it from `lower bound = -0.015, upper bound = 0.005` to `lower bound = -0.005, upper bound of 0.015` so that the natural TWAP falls below and we snap to `-0.005`.

Also fixed some formatting issues.