### PR TITLE
chore: comment out the cosmic-carryover

### DIFF
--- a/protocol/cosmic-features.json
+++ b/protocol/cosmic-features.json
@@ -923,5 +923,21 @@
   "Unknown": {
     "milestone": "unknown",
     "acs": []
+  },
+  "Iceberg Orders": {
+    "milestone": "cosmic-carryover",
+    "acs": ["0014-ORDT-069"]
+  },
+  "Successor Markets": {
+    "milestone": "cosmic-carryover",
+    "acs": ["0001-MKTF-008"]
+  },
+  "Ethereum oracles": {
+    "milestone": "cosmic-carryover",
+    "acs": ["0082-ETHD-035", "0082-ETHD-041"]
+  },
+  "Stop Orders": {
+    "milestone": "cosmic-carryover",
+    "acs": ["0079-TGAP-004", "0079-TGAP-005", "0014-ORDT-132", "0014-ORDT-133", "0014-ORDT-134", "0014-ORDT-135", "0014-ORDT-136"]
   }
 }

--- a/protocol/features.json
+++ b/protocol/features.json
@@ -1,5 +1,5 @@
 {
-  "Iceberg Orders": {
+  /*"Iceberg Orders": {
     "milestone": "cosmic-carryover",
     "acs": ["0014-ORDT-069"]
   },
@@ -14,7 +14,7 @@
   "Stop Orders": {
     "milestone": "cosmic-carryover",
     "acs": ["0079-TGAP-004", "0079-TGAP-005", "0014-ORDT-132", "0014-ORDT-133", "0014-ORDT-134", "0014-ORDT-135", "0014-ORDT-136"]
-  },
+  },*/
   "Perpetuals": {
     "milestone": "palazzo",
     "acs": [

--- a/protocol/features.json
+++ b/protocol/features.json
@@ -1,20 +1,4 @@
 {
-  /*"Iceberg Orders": {
-    "milestone": "cosmic-carryover",
-    "acs": ["0014-ORDT-069"]
-  },
-  "Successor Markets": {
-    "milestone": "cosmic-carryover",
-    "acs": ["0001-MKTF-008"]
-  },
-  "Ethereum oracles": {
-    "milestone": "cosmic-carryover",
-    "acs": ["0082-ETHD-035", "0082-ETHD-041"]
-  },
-  "Stop Orders": {
-    "milestone": "cosmic-carryover",
-    "acs": ["0079-TGAP-004", "0079-TGAP-005", "0014-ORDT-132", "0014-ORDT-133", "0014-ORDT-134", "0014-ORDT-135", "0014-ORDT-136"]
-  },*/
   "Perpetuals": {
     "milestone": "palazzo",
     "acs": [


### PR DESCRIPTION
This moves the cosmic carry over into the cosmic.json file so we know what we left in terms of testing for that milestone