### PR TITLE
chore: add AC thats pushed from palazzo milestone

### DIFF
--- a/protocol/nebula-features.json
+++ b/protocol/nebula-features.json
@@ -26,6 +26,10 @@
       "0028-GOVE-177"
     ]
   },
+  "Perpetual funding rates": {
+    "milestone": "nebula",
+    "acs": ["0053-PERP-036"]
+  },
   "Unknown": {
     "milestone": "unknown",
     "acs": []


### PR DESCRIPTION
As per:

- https://github.com/vegaprotocol/specs/pull/2127

This adds inthe AC code that cant be tested in palazzo due to the following issue:

- https://github.com/vegaprotocol/vega/issues/10360