### PR TITLE
Capped futures

### DIFF
--- a/protocol/0016-PFUT-product_builtin_future.md
+++ b/protocol/0016-PFUT-product_builtin_future.md
@@ -14,6 +14,13 @@ Futures are a simple "delta one" product and the first product supported by Vega
 
 Validation: none required as these are validated by the asset and data source frameworks.
 
+Optional parameters:
+
+1. `max_price`: specifies the price cap for the market, an integer understood in the context of market decimal places,
+1. `binary_settlement`: if set to `true` settlement price other than `0` or `max_price` will be ignored.
+
+Validation: `max_price` > 0.
+
 ## 2. Settlement assets
 
 1. Returns `[cash_settled_future.settlement_asset]`.
@@ -55,6 +62,30 @@ cash_settled_future.settlement_data(event) {
 }
 ```
 
+## 2. Additional considerations around optional parameters
+
+Optional parameters allow creating capped futures (all prices including settlement price must be in the range `[0, max_price]`) or binary options (all intermediate prices must be in the range `[0, max_price]`, settlement price bust be either `0` or `max_price`) markets.
+
+### 2.1 Order price validation
+
+If `max_price` is specified the order prices should be validated so that the maximum price of any order is `max_price`. Peg orders should be validated so that if the resulting price would be higher at any point it gets temporarily capped at `max_price`.
+
+### 2.2 Mark price validation
+
+If `max_price` is specified, mark price candidates greater than `max_price` should be ignored and [mark-to-market settlement](./0003-MTMK-mark_to_market_settlement.md) should not be carried out until a mark price within the `[0, max_price]` range arrives.
+
+### 2.3 Settlement price validation
+
+If `max_price` is specified:
+
+- When `binary_settlement` parameter is set to `false` any value `0 <= settlement_price <= max_price` should be accepted as a settlement price.
+- When `binary_settlement` parameter is set to `true` only `settlement_price=0` or `settlement_price=max_price` should be accepted.
+- Any other values get ignored and market does not settle, instead it still waits for subsequent values from the settlement oracle until a value which passes the above conditions arrives.
+
+## 3. Binary options
+
+Please note that selecting a future prodcut with `max_price` specified and `binary_settlement` flag set to `true` allows representing binary options markets.
+
 ## Acceptance Criteria
 
 1. Create a Cash Settled Future with trading termination triggered by a date/time based data source (<a name="0016-PFUT-001" href="#0016-PFUT-001">0016-PFUT-001</a>)
@@ -69,3 +100,19 @@ cash_settled_future.settlement_data(event) {
 1. Lifecycle events are processed atomically as soon as they are triggered, i.e. the above condition always holds even for two or more transactions arriving at effectively the same time - only the transaction that is sequenced first triggers final settlement (<a name="0016-PFUT-010" href="#0016-PFUT-010">0016-PFUT-010</a>)
 1. Once a market is finally settled, the mark price is equal to the settlement data and this is exposed on event bus and market data APIs (<a name="0016-PFUT-011" href="#0016-PFUT-011">0016-PFUT-011</a>)
 1. Assure [settment-at-expiry.feature](https://github.com/vegaprotocol/vega/blob/develop/core/integration/features/verified/0002-STTL-settlement_at_expiry.feature) executes correctly (<a name="0016-PFUT-012" href="#0016-PFUT-012">0016-PFUT-012</a>)
+
+Optional parameters:
+
+1. Attempt to specify a `max_price` of `0` fails. (<a name="0016-PFUT-013" href="#0016-PFUT-013">0016-PFUT-013</a>)
+1. When `max_price` is specified, an order with a `price > max_price` gets rejected. (<a name="0016-PFUT-014" href="#0016-PFUT-014">0016-PFUT-014</a>)
+1. When `max_price` is specified and the reference of a pegged sell order moves so that the implied order price is higher than `max_price` the implied order price gets capped at. `max_price` (<a name="0016-PFUT-015" href="#0016-PFUT-015">0016-PFUT-015</a>)
+1. When `max_price` is specified and market is setup to use oracle based mark price and the value received from oracle is less than `max_price` then it gets used as is and mark-to-market flows are calculated according to that price. (<a name="0016-PFUT-016" href="#0016-PFUT-016">0016-PFUT-016</a>)
+1. When `max_price` is specified and the market is setup to use oracle based mark price and the value received from oracle is greater than `max_price` then it gets ignored and mark-to-market settlement doesn't occur until a mark price candidate within the `[0, max_price]` range arrives. (<a name="0016-PFUT-017" href="#0016-PFUT-017">0016-PFUT-017</a>)
+1. When `max_price` is specified and `binary_settlement` flag is set to `false`, and the final settlement price candidate received from the oracle is less than or equal to `max_price` then it gets used as is and the final cashflows are calculated according to that price. (<a name="0016-PFUT-018" href="#0016-PFUT-018">0016-PFUT-018</a>)
+1. When `max_price` is specified and the final settlement price candidate received from the oracle is greater than  `max_price` the value gets ignored, next a value equal to `max_price` comes in from the settlement oracle and market settles correctly. The market behaves in this way irrespective of how `binary_settlement` flag is set. (<a name="0016-PFUT-019" href="#0016-PFUT-019">0016-PFUT-019</a>)
+1. When `max_price` is specified, the `binary_settlement` flag is set to `true` and the final settlement price candidate received from the oracle is greater than `0` and less than  `max_price` the value gets ignored, next a value of `0` comes in from the settlement oracle and market settles correctly. (<a name="0016-PFUT-020" href="#0016-PFUT-020">0016-PFUT-020</a>)
+1. When `max_price` is specified and the market is ran in a [fully-collateralised mode](./0019-MCAL-margin_calculator.md#fully-collateralised) and it has parties with open positions settling it at a price of `max_price` works correctly and the sum of all final settlement cashflows equals 0 (loss socialisation does not happen). Assuming general account balances of all parties were `0` after opening the positions and all of their funds were in the margin accounts: long parties end up with balances equal to `position size * max_price` and short parties end up with `0` balances. (<a name="0016-PFUT-021" href="#0016-PFUT-021">0016-PFUT-021</a>)
+1. When `max_price` is specified and the market is ran in a [fully-collateralised mode](./0019-MCAL-margin_calculator.md#fully-collateralised) and it has parties with open positions settling it at a price of `0` works correctly and the sum of all final settlement cashflows equals 0 (loss socialisation does not happen). Assuming general account balances of all parties were `0` after opening the positions and all of their funds were in the margin accounts: short parties end up with balances equal to `abs(position size) * max_price` and long parties end up with `0` balances. (<a name="0016-PFUT-022" href="#0016-PFUT-022">0016-PFUT-022</a>)
+1. When `max_price` is specified and the market is ran in a [fully-collateralised mode](./0019-MCAL-margin_calculator.md#fully-collateralised)  and a party opens a long position at a `max_price`, no closeout happens when mark to market settlement is carried out at a price of `0`. (<a name="0016-PFUT-023" href="#0016-PFUT-023">0016-PFUT-023</a>)
+1. When `max_price` is specified and the market is ran in a [fully-collateralised mode](./0019-MCAL-margin_calculator.md#fully-collateralised)  and a party opens a short position at a price of `0`, no closeout happens when mark to market settlement is carried out at a `max_price`. (<a name="0016-PFUT-024" href="#0016-PFUT-024">0016-PFUT-024</a>)
+1. Futures market can be created without specifying any of the [optional paramters](#1-product-parameters). (<a name="0016-PFUT-025" href="#0016-PFUT-025">0016-PFUT-025</a>)

--- a/protocol/0018-RSKM-quant_risk_models.ipynb
+++ b/protocol/0018-RSKM-quant_risk_models.ipynb
@@ -103,6 +103,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapped risk models\n",
+    "\n",
+    "For certain products it might be possible to certain aspects of market's reliance on risk model while keeping other dependencies in places.\n",
+    "\n",
+    "### Fully-collateralised\n",
+    "\n",
+    "For products with pre-defined finite price range (e.g. [a futures contracts with [`max_price`](./0016-PFUT-product_builtin_future.md#1-product-parameters) parameter specified]) it is possible to make positions fully-collateralised so that for any position a margin can be chosen such that the party stays solvent at any price the market may attain. Using this mode removes the reliance on risk-factors, however the risk model might still be used for other aspects of market's functioning. To signify this and make it transparent to the user a fully-collateralised wrapped risk model is used in those cases."
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/protocol/0019-MCAL-margin_calculator.md
+++ b/protocol/0019-MCAL-margin_calculator.md
@@ -425,6 +425,16 @@ There should be an additional amount `limit price x size x margin factor = 15910
 - All order margin balances are restored after a protocol upgrade (<a name="0019-MCAL-152" href="#0019-MCAL-152">0019-MCAL-152</a>).
 - The `margin mode` and `margin factor` of any given party must be preserved after a protocol upgrade (<a name="0019-MCAL-153" href="#0019-MCAL-153">0019-MCAL-153</a>).
 
+## Acceptance Criteria (Fully collateralised mode)
+
+Assume a [capped future](./0093-CFUT-product_builtin_capped_future.md) market with a `max price = 100` and mark-to-market cashflows being exchanged every block:
+
+- Party A posts an order to buy `10` contracts at a price of `30`, there's no other volume in that price range so the order lands on the book and the  maintenance and initial margin levels for the party and order margin account balance are all equal to `300`. (<a name="0019-MCAL-154" href="#0019-MCAL-154">0019-MCAL-154</a>)
+- Party B posts an order to sell `15` contracts at a price of `20`, a trade is generated for `10` contracts at price of `30` with party A. The maintenance and initial margin levels party A remains at `300`, order margin account balance is now `0` and margin account balance is `300`, the position is `10` and there are no open orders. The  maintenance and initial margin levels for party B are equal to `10 * (100 - 30) + 5 * (100 - 20) = 1100`, the margin account balance is `700`, order margin account balance is `400`, the position is `-10` and the remaining volume on the book from this party is `5` at a price of `20`. (<a name="0019-MCAL-155" href="#0019-MCAL-155">0019-MCAL-155</a>)
+- Party B posts an order to buy `10` contracts at a price of `18`, the orders get placed on the book and margin levels as well margin account balances and position remain unchanged. (<a name="0019-MCAL-156" href="#0019-MCAL-156">0019-MCAL-156</a>)
+- Party B posts an order to buy `30` contracts at a price of `16`, the orders get placed on the book, the maintenance and initial margin levels for party B grow to `1180`, and the margin account balance remains unchanged at `700` and the order margin account balance grows to `480 = max (5 * (100 - 20), 30 * 16)`. The position remains unchanged at `-10`. (<a name="0019-MCAL-157" href="#0019-MCAL-157">0019-MCAL-157</a>)
+- Party A posts an order to sell `20` contracts at a price of `17`. A trade is generated for `10` contracts at a price of `18` with party B. A sell order for `10` contracts at a price of `17` from party A gets added to the book. The maintenance and initial margin levels for party A is now `10 * (100 - 17) = 830`, the position is `0` and the remaining volume on the book from this party is `10` at a price of `18`. Party A lost `120` on its position, hence `830 - (300 - 120) = 410` additional funds get moved from the general account as part of the transaction which submitted the order to sell `20` at `17`. Party B now has a position of `0` and following orders open on the book: sell `5` at `20` and buy `30` at `16`. The maintenance and initial margin levels are `max(5 * (100 - 20), 30 * 16) = 480`. The margin account momentarily becomes `820` (`700` + `120` of gains from the now closed position of `-10`), order margin account balance is `480`, hence `820` gets released back into the general account and margin account becomes `0`. (<a name="0019-MCAL-158" href="#0019-MCAL-158">0019-MCAL-158</a>)
+
 ## Summary
 
 The *margin calculator* returns the set of margin levels for a given *actual position*, along with the amount of additional margin (if any) required to support the party's *potential position* (i.e. active orders including any that are parked/untriggered/undeployed).
@@ -432,7 +442,9 @@ The *margin calculator* returns the set of margin levels for a given *actual pos
 
 ### Margining modes
 
-The system can operate in one of two margining modes for each position.
+#### Partially-collateralised
+
+The system can operate in one of two partially-collateralised margining modes for each position.
 The current mode will be stored alongside of party's position record.
 
 1. **Cross-margin mode (default)**: this is the mode used by all newly created positions.
@@ -443,6 +455,23 @@ In this mode, the entire margin for any newly opened position volume is transfer
 This includes completely new positions and increases to position size. Other than at time of future trades, the general account will then
 *never* be searched for additional funds (a position will be allowed to be closed out instead), nor will profits be moved into the
 general account from the margin account.
+
+#### Fully-collateralised
+
+For certain derivatives markets it may be possible to collateralise the position in full so that there's no default risk for any party.
+
+If a product specifies an upper bound on price (`max price`) (e.g. [capped future](./0093-CFUT-product_builtin_capped_future.md)) then a fully-collateralised [wrapped risk model](./0018-RSKM-quant_risk_models.ipynb) can be specified for the market. If such a risk model is chosen then, it's mandatory for all parties (it's not possible to self-select any of the above partially-collateralised margining modes).
+
+In this mode long positions provide `position size * average entry price` in initial margin, whereas shorts provide `postion size * (max price - average entry price)`. The initial margin level is only re-evaluated when party changes their position. The [mark-to-market](./0003-MTMK-mark_to_market_settlement.md) is carried out as usual. Maintenance and initial margin levels should be set to the same value.  Margin search and release levels are set to `0` and never used.
+
+In this mode it is not possible for a party to be liquidated. Even if the price moves to the extremes of zero or the `max price` and parties may therefore have zero in their margin account, the parties must not be liquidated. Fully collateralised means that the posted collateral explicitly covers all eventualities and positions will only be closed at final settlement at maturity.
+
+Order margin is calculated as per [isolated margin mode](#placing-an-order) with:
+
+- `side margin = limit price * size` for buy orders
+- `side margin = (max price - limit price) * size` for sell orders.
+
+Same calculation should be applied during auction (unlike in isolated margin mode).
 
 ### Actual position margin levels
 

--- a/protocol/features.json
+++ b/protocol/features.json
@@ -25,22 +25,29 @@
   },
   "Isolated margin": {
     "milestone": "colosseo",
-    "acs": ["0019-MCAL-208"]
+    "acs": [
+      "0019-MCAL-208"
+    ]
   },
   "Closeout trades and auctions": {
     "milestone": "colosseo",
-    "acs": ["0012-POSR-030"]
+    "acs": [
+      "0012-POSR-030"
+    ]
   },
   "Market suspended/resumed before enactment": {
     "milestone": "colosseo",
     "acs": [
-    "0043-MKTL-011", 
-    "0043-MKTL-012",
-    "0043-MKTL-013"]
+      "0043-MKTL-011",
+      "0043-MKTL-012",
+      "0043-MKTL-013"
+    ]
   },
   "Teams": {
     "milestone": "colosseo",
-    "acs": ["0083-RFPR-068"]
+    "acs": [
+      "0083-RFPR-068"
+    ]
   },
   "Spot": {
     "milestone": "colosseo",
@@ -533,11 +540,17 @@
   },
   "Perpetual funding rates": {
     "milestone": "colosseo",
-    "acs": ["0053-PERP-036"]
+    "acs": [
+      "0053-PERP-036"
+    ]
   },
   "Explicit liquidation range": {
     "milestone": "colosseo",
-    "acs": ["0012-POSR-031", "0012-POSR-032", "0012-POSR-033"]
+    "acs": [
+      "0012-POSR-031",
+      "0012-POSR-032",
+      "0012-POSR-033"
+    ]
   },
   "Community Tags": {
     "milestone": "colosseo",
@@ -557,7 +570,9 @@
   },
   "LPs voting without gov token": {
     "milestone": "colosseo",
-    "acs": ["0028-GOVE-185"]
+    "acs": [
+      "0028-GOVE-185"
+    ]
   },
   "Reward Improvements": {
     "milestone": "colosseo",
@@ -658,6 +673,29 @@
       "0014-NP-VAMM-001",
       "0014-NP-VAMM-002",
       "0014-NP-VAMM-003"
+    ]
+  },
+  "Capped Futures": {
+    "milestone": "colosseo_II",
+    "acs": [
+      "0016-PFUT-013",
+      "0016-PFUT-014",
+      "0016-PFUT-015",
+      "0016-PFUT-016",
+      "0016-PFUT-017",
+      "0016-PFUT-018",
+      "0016-PFUT-019",
+      "0016-PFUT-020",
+      "0016-PFUT-021",
+      "0016-PFUT-022",
+      "0016-PFUT-023",
+      "0016-PFUT-024",
+      "0016-PFUT-025",
+      "0019-MCAL-154",
+      "0019-MCAL-155",
+      "0019-MCAL-156",
+      "0019-MCAL-157",
+      "0019-MCAL-158"
     ]
   },
   "Unknown": {


### PR DESCRIPTION
Minimal spec changes required to allow creation of fully-collateralised binary options markets.

The main things left to decide:
1.  ~~If we want to allow capping of perps?~~  No.

2. ~~If we go with 1. do we want to allow fully-collateralised mode with perps?~~  No.

Closes https://github.com/vegaprotocol/specs/issues/2230