### PR TITLE
feat: calculate fraction of cumulative taker volume across window

### DIFF
--- a/protocol/0095-HVMR-high_volume_maker_rebate.md
+++ b/protocol/0095-HVMR-high_volume_maker_rebate.md
@@ -11,7 +11,51 @@ Enabling or changing the terms of the program can be proposed via governance. As
   - `minimum_party_maker_volume_fraction`: the required `party_maker_volume_fraction` for a party to access this tier
   - `additional_maker_rebate`: the additional rebate factor (in percentage of `trade_value_for_fee_purposes`) a party at this tier will receive when they are the maker side of a trade
 - `end_of_program_timestamp`: the timestamp after which when the current epoch ends, the program will become inactive and benefits will be disabled. If this field is empty, the program runs indefinitely.
-- `window_length`:  the number of epochs over which to average a party's `maker_volume_fraction`
+- `window_length`:  the number of epochs over which to measure a party's cumulative maker volume.
+
+
+## Calculation
+
+For each party, the network must track the maker volume they created in each epoch.
+
+At the start of an epoch the network should calculate each parties `party_maker_volume_fraction` by calculating what proportion of the maker volume over the last $m$ epochs a party made up (where m is the `window_length` set configured in the program), i.e.
+
+$$\text{partyMakerVolumeFraction} = \frac{\sum_{i=1}^{m}{V_i}_j}{\sum_{i=1}^{m}\sum_{j=1}^{n}{V_i}_j}$$
+
+where:
+
+- ${V_i}_j$ is the maker volume of party `j` in epoch `i`
+
+
+Each parties `additional_maker_rebate` is then fixed to the value in the highest tier they qualify for. A parties tier is defined as the highest tier for which their `party_maker_volume_fraction` is greater or equal to the tiers `minimum_party_maker_volume_fraction`. If a party does not qualify for any tier, their `additional_maker_rebate` is set to `0`.
+
+```pseudo
+Given:
+    benefit_tiers=[
+        {
+            "minimum_party_maker_volume_fraction": 0.1,
+            "additional_maker_rebate": 0.01,
+        },
+        {
+            "minimum_party_maker_volume_fraction": 0.2,
+            "additional_maker_rebate": 0.02,
+
+        },
+        {
+            "minimum_party_maker_volume_fraction": 0.3,
+            "additional_maker_rebate": 0.03,
+
+        },
+    ]
+
+And:
+    party_maker_volume_fraction=0.23
+
+Then:
+    additional_maker_rebate=0.02
+```
+
+This `additional_maker_rebate` factor is then fixed for the duration of the next epoch.
 
 ## Application
 

--- a/spellcheck.yaml
+++ b/spellcheck.yaml
@@ -38,6 +38,12 @@ matrix:
             # Ignore hugo/jinja tags
             - open: '{{'
               close: '}}'
+            # Ignore display LaTeX formulas ($$ ... $$)
+            - open: '\$\$'
+              close: '\$\$'
+            # Ignore display LaTeX formulas ($$ ... $$)
+            - open: '\$'
+              close: '\$'
       - pyspelling.filters.markdown: null
       - pyspelling.filters.html:
           comments: false


### PR DESCRIPTION
PR updates maker rebate spec so a parties fraction of maker volume is measured as the fraction of cumulative maker volume over the last n epochs rather than the average of each fraction of maker volume over the last n epochs.