### PR TITLE
feat: restricted ELS assets and changes to accrual

### DIFF
--- a/protocol/0040-ASSF-asset_framework.md
+++ b/protocol/0040-ASSF-asset_framework.md
@@ -229,7 +229,7 @@ Built-in assets work much the same as any Vega asset except they can not be depo
 - as the quote asset in a spot market
 - as the settlement asset in a derivatives market (future or perpetual)
 
-These restrictions should be updatable at any point through governance. When updating an asset the following cases should be considered:
+These restrictions can be updated at any point through governance. When updating an asset the following cases should be considered:
 
 - given an asset allows transfers, if a delayed one-off or recurring transfer is created and then the asset is updated to not allow transfers, any outstanding transfers are not cancelled and are executed as normal.
 - given an asset allows use as a base, quote, or settlement asset, if a market is created using the asset and the asset is later updated to not allow the respective use, the market is not cancelled and should operate as normal.

--- a/protocol/0040-ASSF-asset_framework.md
+++ b/protocol/0040-ASSF-asset_framework.md
@@ -67,6 +67,7 @@ message DevAssets {
 }
 
 message AssetRestrictions {
+  bool faucetEnabled = 1;
   bool transferEnabled = 1;
   bool baseAssetEnabled = 1;
   bool quoteAssetEnabled = 1;
@@ -222,8 +223,11 @@ This section will be expanded if additional ethereum based token standards are s
 
 #### Built-In Assets
 
-Built-in assets work much the same as any Vega asset except they can not be deposited or withdrawn. They also optionally can be restricted from use in specific functions. These functions include:
+Built-in assets work much the same as any Vega asset except they can not be deposited or withdrawn. The creation of internal assets through governance proposals is restricted by the network parameter, `limits.assets.proposeBuiltinEnabled`.
 
+They also optionally can be restricted from use in specific functions. These functions include:
+
+- minting
 - transfers
 - as the base asset in a spot market
 - as the quote asset in a spot market

--- a/protocol/0040-ASSF-asset_framework.md
+++ b/protocol/0040-ASSF-asset_framework.md
@@ -53,6 +53,7 @@ message BuiltinAsset {
   string symbol = 3;
   string totalSupply = 4;
   uint64 decimals = 5;
+  AssetRestrictions assetRestrictions = 6;
 }
 
 message ERC20 {
@@ -63,6 +64,13 @@ message ERC20 {
 
 message DevAssets {
   repeated AssetSource sources = 1;
+}
+
+message AssetRestrictions {
+  bool transferEnabled = 1;
+  bool baseAssetEnabled = 1;
+  bool quoteAssetEnabled = 1;
+  bool settlementAssetEnabled = 1;
 }
 ```
 
@@ -211,6 +219,20 @@ NOTE 2: Before running this function, the user must run the ERC-20-standard `app
 ##### Other Ethereum Token Standards (Depositing)
 
 This section will be expanded if additional ethereum based token standards are supported by Vega. New bridges will be expected to implement `IVega_Bridge`.
+
+#### Built-In Assets
+
+Built-in assets work much the same as any Vega asset except they can not be deposited or withdrawn. They also optionally can be restricted from use in specific functions. These functions include:
+
+- transfers
+- as the base asset in a spot market
+- as the quote asset in a spot market
+- as the settlement asset in a derivatives market (future or perpetual)
+
+These restrictions should be updatable at any point through governance. When updating an asset the following cases should be considered:
+
+- given an asset allows transfers, if a delayed one-off or recurring transfer is created and then the asset is updated to not allow transfers, any outstanding transfers are not cancelled and are executed as normal.
+- given an asset allows use as a base, quote, or settlement asset, if a market is created using the asset and the asset is later updated to not allow the respective use, the market is not cancelled and should operate as normal.
 
 #### Other Assets
 

--- a/protocol/0096-LIQM-liquidity_mechanisms.md
+++ b/protocol/0096-LIQM-liquidity_mechanisms.md
@@ -57,7 +57,7 @@ A boolean, defaulting to `false`, which sets whether internal assets representin
 
 Note, the restriction on the asset can always be updated later through governance.
 
-# Mechanisms
+## Mechanisms
 
 There are three liquidity mechanisms that take place at the end of the epoch.
 
@@ -72,7 +72,7 @@ It is critical these stages are done in this order so that:
 
 Note, sections in this specification are not listed in the order in which they should be executed but are instead ordered for readability. Refer to the list above for order of execution.
 
-## Designating Liquidity Providers
+### Designating Liquidity Providers
 
 A party will only be able to accrue ELS points, receive liquidity fees, or earn liquidity rewards providing they are designated as an LP for that epoch.
 
@@ -90,13 +90,13 @@ By designating parties as LPs on an epoch by epoch basis the protocol ensures:
 - "in-active" parties with a large number of ELS points will no longer be rewarded through liquidity mechanisms should they stop providing liquidity (or provide un-competitive liquidity).
 - "late-arriving" parties with a small number of ELS points will be rewarded through liquidity mechanisms if they provide competitive liquidity and as such comprise a larger proportion of the markets volume.
 
-## ELS Points
+### ELS Points
 
-### Creating ELS points
+#### Creating ELS points
 
 Whenever a market proposal is enacted (passes opening auction), an internal Vega asset is created to track the ELS points of that market. For a successor market, a new asset should not be created and instead the ELS asset of the parent market should be used.
 
-When ever an internal asset representing ELS points is created the [internal asset restrictions]() are defaulted to the respective [network parameter](#network-parameters). It's quantum should be set using the following formula. Note, both the restrictions and quantum can later be updated through governance.
+When ever an internal asset representing ELS points is created the [internal asset restrictions](./0040-ASSF-asset_framework.md#built-in-assets) are defaulted to the respective [network parameter](#network-parameters). It's quantum should be set using the following formula. Note, both the restrictions and quantum can later be updated through governance.
 
 $$q_{ELS} = \frac{q}{n}$$
 
@@ -110,7 +110,7 @@ The relationship between how many points a party must then accrue before they wi
 
 $$\text{transfer.minTransferQuantumMultiple}\cdot\text{liquidity.els.defaultQuantumFactor}$$
 
-### Accruing ELS points
+#### Accruing ELS points
 
 At the end of each epoch, each party designated as an LP accrues ELS points for the relevant market as follows:
 
@@ -126,7 +126,7 @@ Where:
 > the maker fees is scaled by the assets quantum such that 1 ELS point is earned for approx. every 1 USD of maker fees received.
 
 
-## Volume of Notional
+### Volume of Notional
 
 The volume of notional is a measure of how much liquidity an LP provided to a market throughout the epoch.
 
@@ -137,7 +137,7 @@ The range and required proportion of the epoch are controlled though market conf
 - `lp_price_range`: a number in the range $[0, 100]$ which defines the range in which an LPs orders will contribute towards their volume of notional, refer to section [instantaneous volume-of-notional](#instantaneous volume of notional) for more details.
 - `minimum_time_fraction`: a number in the range $[0, 1]$ which defines the minimum proportion of an epoch an LP must have provided an amount of volume for in order for that amount to be set as their volume of notional, refer to section [calculating the volume of notional](#calculating-the-volume-of-notional) for more details.
 
-### Instantaneous Volume of Notional
+#### Instantaneous Volume of Notional
 
 To calculate each LPs volume of notional, throughout the epoch, the network must sample and store the current volume of notional supplied by each LP at that point. Call this the instantaneous volume of notional. For now this is done once a block but could be sampled randomly to reduce the amount of data stored.
 
@@ -166,13 +166,13 @@ Whilst in monitoring auctions:
 
 - If there is no 'indicative uncrossing price' each LP is treated as supplying `0` volume.
 
-### Calculating the Volume of Notional
+#### Calculating the Volume of Notional
 
 At the end of the epoch, before distributing fees, each LPs `volume of notional` is set to the largest volume of notional that was supplied for at least a specified proportion of the epoch, i.e. in a sorted array of supplied liquidity amounts, the commitment amount would be element $i$ where:
 
 $$i= \lceil\text{len(array)}\cdot{\text{minTimeFraction}}\rceil$$
 
-## Distributing Liquidity Fees
+### Distributing Liquidity Fees
 
 At the end of epoch, before new LPs are delegated and each party accrues ELS points for that epochs volume, the accumulated liquidity fees are distributed pro-rata amongst liquidity providers weighted by their accrued ELS points and volume of notional as follows.
 

--- a/protocol/0096-LIQM-liquidity_mechanisms.md
+++ b/protocol/0096-LIQM-liquidity_mechanisms.md
@@ -29,7 +29,7 @@ Updates to this parameter will be used the next time LPs are designated, i.e. up
 
 ### `liquidity.els.defaultQuantumFactor`
 
-A number in the range $[0, 100]$ which defines the amount to scale the quantum of the markets settlement or quote asset by (for derivative and spot markets respectively) when setting the initial quantum of the internal asset representing the ELS points for the market.
+A number in the range $(0, 10000]$ which defines the amount to scale the quantum of the markets settlement or quote asset by (for derivative and spot markets respectively) when setting the initial quantum of the internal asset representing the ELS points for the market.
 
 Note, this parameter influences the minimum amount of ELS points a party will have to accrue before being able to transfer.
 
@@ -96,7 +96,7 @@ By designating parties as LPs on an epoch by epoch basis the protocol ensures:
 
 Whenever a market proposal is enacted (passes opening auction), an internal Vega asset is created to track the ELS points of that market. For a successor market, a new asset should not be created and instead the ELS asset of the parent market should be used.
 
-When ever an internal asset representing ELS points is created the [internal asset restrictions](./0040-ASSF-asset_framework.md#built-in-assets) are defaulted to the respective [network parameter](#network-parameters). It's quantum should be set using the following formula. Note, both the restrictions and quantum can later be updated through governance.
+When ever an internal asset representing ELS points is created the [internal asset restrictions](./0040-ASSF-asset_framework.md#built-in-assets) are defaulted to the respective [network parameter](#network-parameters). Its quantum should be set using the following formula. Note, both the restrictions and quantum can later be updated through governance.
 
 $$q_{ELS} = \frac{q}{n}$$
 

--- a/protocol/0096-LIQM-liquidity_mechanisms.md
+++ b/protocol/0096-LIQM-liquidity_mechanisms.md
@@ -27,9 +27,57 @@ A number in the range $[0, 1]$ which defines the minimum proportion of a markets
 
 Updates to this parameter will be used the next time LPs are designated, i.e. updating the network parameter will not result in LPs instantly being re-designated.
 
-## Accruing ELS Points
+### `liquidity.els.defaultQuantumFactor`
+
+A number in the range $[0, 100]$ which defines the amount to scale the quantum of the markets settlement or quote asset by (for derivative and spot markets respectively) when setting the initial quantum of the internal asset representing the ELS points for the market.
+
+Note, this parameter influences the minimum amount of ELS points a party will have to accrue before being able to transfer.
+
+### `liquidity.els.transferEnabled`
+
+A boolean, defaulting to `true`, which sets whether internal assets representing ELS points are allowed to be transferred when the asset is first created.
+
+Note, the restriction on the asset can always be updated later through governance.
+
+### `liquidity.els.settlementAssetEnabled`
+
+A boolean, defaulting to `false`, which sets whether internal assets representing ELS points are allowed to be used as the settlement asset of a derivative market when they are first created.
+
+Note, the restriction on the asset can always be updated later through governance.
+
+### `liquidity.els.baseAssetEnabled`
+
+A boolean, defaulting to `false`, which sets whether internal assets representing ELS points are allowed to be used as the base asset of a spot market when they are first created.
+
+Note, the restriction on the asset can always be updated later through governance.
+
+### `liquidity.els.quoteAssetEnabled`
+
+A boolean, defaulting to `false`, which sets whether internal assets representing ELS points are allowed to be used as the quote asset of a spot market when they are first created.
+
+Note, the restriction on the asset can always be updated later through governance.
+
+## ELS Points
+
+### Creating ELS points
 
 Whenever a market proposal is enacted (passes opening auction), an internal Vega asset is created to track the ELS points of that market. For a successor market, a new asset should not be created and instead the ELS asset of the parent market should be used.
+
+When ever an internal asset representing ELS points is created the [internal asset restrictions]() are defaulted to the respective [network parameter](#network-parameters). It's quantum should be set using the following formula. Note, both the restrictions and quantum can later be updated through governance.
+
+$$q_{ELS} = \frac{q}{n}$$
+
+where:
+
+- $q_{ELS}$ is the quantum of the internal asset representing the  
+- $q$ is the quantum of the settlement or quote asset depending on whether the market is a derivative or spot market.
+- $n$ is the network parameter `liquidity.els.defaultQuantumFactor`
+
+The relationship between how many points a party must then accrue before they will have enough to pass spam protection when transferring assets can simply be thought of as:
+
+$$\text{transfer.minTransferQuantumMultiple}\cdot\text{liquidity.els.defaultQuantumFactor}$$
+
+### Accruing ELS points
 
 At the end of each epoch, each party accrues ELS points for the relevant market as follows:
 

--- a/protocol/0096-LIQM-liquidity_mechanisms.md
+++ b/protocol/0096-LIQM-liquidity_mechanisms.md
@@ -21,7 +21,7 @@ The mechanisms also enable the following features:
 
 ## Network parameters
 
-### `liquidityProvider.proportionRequirement`
+### `liquidity.providers.makerRequirement`
 
 A number in the range $[0, 1]$ which defines the minimum proportion of a markets maker fees a party must receive in order to be [designated](#designating-liquidity-providers) as an LP for the next epoch. The parameter should default to `0.1`.
 
@@ -96,14 +96,14 @@ Where:
 
 A party will only be able to receive liquidity fees or earn liquidity rewards providing they are designated as an LP for that epoch.
 
-A party will only be designated as an LP providing they received more than a specified proportion of the markets total maker fees in the previous epoch, let this requirement be $N$ (the network parameter `liquidityProvider.proportionRequirement`). Throughout the epoch the network will track each parties maker fees, $M$.  At the end of epoch $i$, a party will be designated as an LP for epoch $i+1$ providing:
+A party will only be designated as an LP providing they received more than a specified proportion of the markets total maker fees in the previous epoch, let this requirement be $N$ (the network parameter `liquidity.providers.makerRequirement`). Throughout the epoch the network will track each parties maker fees, $M$.  At the end of epoch $i$, a party will be designated as an LP for epoch $i+1$ providing:
 
 $$\frac{M_{i_j}}{\sum_{k}^{n}{M_{i_j}}} >= N$$
 
 Where:
 
 - $M_{i_j}$ is the maker fees of party ${j}$ in epoch ${i}$
-- $N$ the requirement specified by the network parameter `liquidityProvider.proportionRequirement`
+- $N$ the requirement specified by the network parameter `liquidity.providers.makerRequirement`
 
 By designating parties as LPs on an epoch by epoch basis the protocol ensures:
 

--- a/protocol/0096-LIQM-liquidity_mechanisms.md
+++ b/protocol/0096-LIQM-liquidity_mechanisms.md
@@ -96,7 +96,9 @@ By designating parties as LPs on an epoch by epoch basis the protocol ensures:
 
 Whenever a market proposal is enacted (passes opening auction), an internal Vega asset is created to track the ELS points of that market. For a successor market, a new asset should not be created and instead the ELS asset of the parent market should be used.
 
-When ever an internal asset representing ELS points is created the [internal asset restrictions](./0040-ASSF-asset_framework.md#built-in-assets) are defaulted to the respective [network parameter](#network-parameters). Its quantum should be set using the following formula. Note, both the restrictions and quantum can later be updated through governance.
+When ever an internal asset representing ELS points is created the [internal asset restrictions](./0040-ASSF-asset_framework.md#built-in-assets) are defaulted to the respective [network parameter](#network-parameters). Note the faucet restriction has no equivalent network parameter as minting through a faucet should be restricted for these assets and minting should be controlled by the protocol as per the mechanisms defined in [accruing ELS points](#accruing-els-points).
+
+The assets quantum should be set using the following formula. Note, both the restrictions and quantum can later be updated through governance.
 
 $$q_{ELS} = \frac{q}{n}$$
 

--- a/protocol/0096-LIQM-liquidity_mechanisms.md
+++ b/protocol/0096-LIQM-liquidity_mechanisms.md
@@ -62,13 +62,13 @@ Note, the restriction on the asset can always be updated later through governanc
 There are three liquidity mechanisms that take place at the end of the epoch.
 
 1. Liquidity fees are distributed amongst liquidity providers
-2. New liquidity providers are delegated
+2. New liquidity providers are designated
 3. The new liquidity providers accrue ELS points
 
 It is critical these stages are done in this order so that:
 
-- Liquidity fees are distributed only to parties who were delegated as LPs for the epoch that is ending.
-- ELS points are accrued by parties who have been delegated for the next epoch based on the volume they created in the epoch that is ending.
+- Liquidity fees are distributed only to parties who were designated as LPs for the epoch that is ending.
+- ELS points are accrued by parties who have been designated for the next epoch based on the volume they created in the epoch that is ending.
 
 Note, sections in this specification are not listed in the order in which they should be executed but are instead ordered for readability. Refer to the list above for order of execution.
 
@@ -174,7 +174,7 @@ $$i= \lceil\text{len(array)}\cdot{\text{minTimeFraction}}\rceil$$
 
 ### Distributing Liquidity Fees
 
-At the end of epoch, before new LPs are delegated and each party accrues ELS points for that epochs volume, the accumulated liquidity fees are distributed pro-rata amongst liquidity providers weighted by their accrued ELS points and volume of notional as follows.
+At the end of epoch, before new LPs are designated and each party accrues ELS points for that epochs volume, the accumulated liquidity fees are distributed pro-rata amongst liquidity providers weighted by their accrued ELS points and volume of notional as follows.
 
 $$f_{i_j} = f_{i} \cdot \frac{ELS_j\cdot{V_j}}{\sum_{k}^{n}{ELS_k\cdot{L_k}}}$$
 

--- a/protocol/0096-LIQM-liquidity_mechanisms.md
+++ b/protocol/0096-LIQM-liquidity_mechanisms.md
@@ -4,8 +4,8 @@
 
 The aim of the on-chain liquidity mechanisms are to reward parties for supplying competitively priced liquidity and facilitating the growth of a market. At a high level, the liquidity mechanisms are:
 
-- parties [accrue](#accruing-els-points) ELS points over time proportional to their maker fees earned.
-- parties are [designated](#designating-liquidity-providers) as LPs on an epoch by epoch basis if they receive above a specified proportion of the markets maker fees.
+- parties [accrue](#accruing-els-points) ELS points over time proportional to their maker volume earned.
+- parties are [designated](#designating-liquidity-providers) as LPs on an epoch by epoch basis if they comprise more than a specified proportion of the markets maker volume.
 - parties [receive](#distributing-liquidity-fees) a proportion of the liquidity fees accumulated in an epoch relative to their [accrued](#accruing-els-points) ELS points and [volume of notional](#volume-of-notional) (but only when designated as an LP).
 
 With the above mechanisms the protocol incentives the following desirable behaviour.
@@ -23,7 +23,7 @@ The mechanisms also enable the following features:
 
 ### `liquidity.providers.makerRequirement`
 
-A number in the range $[0, 1]$ which defines the minimum proportion of a markets maker fees a party must receive in order to be [designated](#designating-liquidity-providers) as an LP for the next epoch. The parameter should default to `0.1`.
+A number in the range $[0, 1]$ which defines the minimum proportion of a markets maker volume a party must comprise in order to be [designated](#designating-liquidity-providers) as an LP for the next epoch. The parameter should default to `0.1`.
 
 Updates to this parameter will be used the next time LPs are designated, i.e. updating the network parameter will not result in LPs instantly being re-designated.
 
@@ -76,13 +76,13 @@ Note, sections in this specification are not listed in the order in which they s
 
 A party will only be able to accrue ELS points, receive liquidity fees, or earn liquidity rewards providing they are designated as an LP for that epoch.
 
-A party will only be designated as an LP providing they received more than a specified proportion of the markets total maker fees in the previous epoch, let this requirement be $N$ (the network parameter `liquidity.providers.makerRequirement`). Throughout the epoch the network will track each parties maker fees, $M$.  At the end of epoch $i$, a party will be designated as an LP for epoch $i+1$ providing:
+A party will only be designated as an LP providing they comprised more than a specified proportion of the markets total maker volume in the previous epoch, let this requirement be $N$ (the network parameter `liquidity.providers.makerRequirement`). Throughout the epoch the network will track each parties maker volume, $M$.  At the end of epoch $i$, a party will be designated as an LP for epoch $i+1$ providing:
 
 $$\frac{M_{i_j}}{\sum_{k}^{n}{M_{i_j}}} >= N$$
 
 Where:
 
-- $M_{i_j}$ is the maker fees of party ${j}$ in epoch ${i}$
+- $M_{i_j}$ is the maker volume of party ${j}$ in epoch ${i}$
 - $N$ the requirement specified by the network parameter `liquidity.providers.makerRequirement`
 
 By designating parties as LPs on an epoch by epoch basis the protocol ensures:
@@ -121,11 +121,11 @@ $$ELS_{i_j} = V_{i_j} \cdot 10^{-Q}$$
 Where:
 
 - $ELS_{j}$ is the ELS points accrued by party $j$ in epoch $i$
-- $V_{i_j}$ is the notional maker fees of party $j$ in epoch $i$
+- $V_{i_j}$ is the notional maker volume of party $j$ in epoch $i$
 - $Q$ is the quantum of the asset in which the markets prices are expressed in (settlement for future and perpetual markets, quote for spot markets)
 
 > [!NOTE]
-> the maker fees is scaled by the assets quantum such that 1 ELS point is earned for approx. every 1 USD of maker fees received.
+> the maker volume is scaled by the assets quantum such that 1 ELS point is earned for approx. every 1 USD of notional volume created.
 
 
 ### Volume of Notional


### PR DESCRIPTION
## Summary

### Restricted internal assets (for ELS)

To enable internal built-in assets too represent ELS points for the new liquidity mechanisms, it is important certain uses are restricted to avoid having to build complicated spam protection for assets which are hard to value (at least initially).

PR updates the asset framework so internal asset can have restrictions set and introduces network parameters to default these values for assets representing ELS points.

PR also introduces a method of defaulting the quantum of these assets.

### Changes to ELS accrual

Only designated LPs should now accrue ELS points. To ensure parties properly accrue points for the volume they generate the order in which steps are executed in the liquidity mechanisms is modified such that.

- Liquidity fees are distributed only to parties who were delegated as LPs for the epoch that is ending.
- ELS points are accrued by parties who have been delegated for the next epoch based on the volume they created in the epoch that is ending.