### PR TITLE
feat: allowed empty AMM levels

### DIFF
--- a/protocol/0001-MKTF-market_framework.md
+++ b/protocol/0001-MKTF-market_framework.md
@@ -35,6 +35,7 @@ Data:
 - **Tick size**: the minimum change in quote price for the market. Order prices and offsets for pegged orders must be given as an exact multiple of the tick size. For example if the tick size is 0.02 USD. then a price of 100.02 USD is acceptable and a price of 100.03 USD is not. The tick size of a market can be updated through governance. Note, the tick size should be specified in terms of the market decimals, e.g. for a scaled tick size of `0.02` (USDT) in a market using `5` decimal places, the tick size would be set to `2000`.
 - **Liquidation strategy**: A field specifying the liquidation strategy for the market. Please refer to [0012-POSR-position_resolution](./0012-POSR-position_resolution.md#managing-networks-position) for supported strategies.
 - **Transaction Prioritisation**: A boolean, whether to enable [transaction prioritisation](./0092-TRTO-trading_transaction_ordering.md).
+- **Empty AMM Price Levels**: An integer greater than or equal to zero which defines the maximum number of price levels permitted in an AMM range which would quote zero volume. This value should default to 100.
 
 Note: it is agreed that initially the integer representation of the full precision of both order and positions can be required to fit into an int64, so this means that the largest position/order size possible reduces by a factor of ten for every extra decimal place used. This also means that, for instance, it would not be possible to create a `BTCUSD` market that allows order/position sizes equivalent to 1 sat.
 

--- a/protocol/0090-VAMM-automated_market_maker.md
+++ b/protocol/0090-VAMM-automated_market_maker.md
@@ -242,11 +242,11 @@ As the volume provided between two ticks can theoretically be less than the smal
 Instead the best-bid and best-ask of an AMM curve is defined as the price levels at which the AMM will quote at least one unit of volume between those prices and the current fair price. Re-arranging the formulas defined in the prior [section](#volume-between-two-prices) yields the following:
 
 $$
-p_{bb} = \frac{L\cdot\sqrt{p_f}}{L + \Delta{P}\cdot \sqrt{p_f}}
+p_{bb} = (\frac{L\cdot\sqrt{p_f}}{L + \Delta{P}\cdot \sqrt{p_f}})^2
 $$
 
 $$
-p_{ba} = \frac{L\cdot\sqrt{p_f}}{L - \Delta{P}\cdot \sqrt{p_f}}
+p_{ba} = (\frac{L\cdot\sqrt{p_f}}{L - \Delta{P}\cdot \sqrt{p_f}})^2
 $$
 
 Where:
@@ -268,13 +268,17 @@ To prevent the protocol evaluating AMMs providing little liquidity to the networ
 
 If the number of ticks in the largest price range in which the AMM quotes zero volume is more than the parameter $allowedEmptyAmmLevels$, then the submission or amendment will be rejected. Note this parameter is defined on each market to allow different markets with varying volatility to be configured appropriately.
 
-- for the lower curve, this range is between the fair price at which the AMMs long position is $P=1$ and the base price.
-- for the upper curve, this range is between the fair price at which the AMMs short position is $(P_v-1)$ and the upper price bound.
+- for the lower curve, this range is between the base price and the best bid price when the fair price is the base price.
+- for the upper curve, this range is between the upper bound and the best bid price when the fair price is the upper bound.
 
 The above definitions yield the following inequality which must be satisfied for both the upper and lower curve (providing they are defined) for the AMM to be valid.
 
 $$
-n\cdot\Delta{p} \geq \frac{L\cdot\sqrt{p_u}}{L + \Delta{P}\cdot \sqrt{p_u}}
+n\cdot\Delta{p} \geq (p_u - p_{bb})
+$$
+
+$$
+n\cdot\Delta{p} \geq {p_u} - (\frac{L\cdot\sqrt{p_u}}{L + \Delta{P}\cdot \sqrt{p_u}})^2
 $$
 
 Where:

--- a/protocol/0090-VAMM-automated_market_maker.md
+++ b/protocol/0090-VAMM-automated_market_maker.md
@@ -167,7 +167,7 @@ $$
 P_{v_u} = \frac{r_f b}{p_u (1 + r_f) - r_f p_a} ,
 $$
 
-where $r_f$ is the `short` factor for the upper range and the `long` factor for the lower range, `b` is the current total balance of the vAMM across all accounts, $P_{v_l}$ is the theoretical volume and the bottom of the lower bound and $P_{v_u}$ is the (absolute value of the) theoretical volume at the top of the upper bound. The final $L$ scores can then be reached with the equation
+where $r_f$ is the `short` factor for the upper range and the `long` factor for the lower range, `b` is the commitment amount, $P_{v_l}$ is the theoretical volume and the bottom of the lower bound and $P_{v_u}$ is the (absolute value of the) theoretical volume at the top of the upper bound. The final $L$ scores can then be reached with the equation
 
 $$
 L = P_v \cdot \frac{\sqrt{p_u} \sqrt{p_l}}{\sqrt{p_u} - \sqrt{p_l}} = P_v L_u,

--- a/protocol/0090-VAMM-automated_market_maker.md
+++ b/protocol/0090-VAMM-automated_market_maker.md
@@ -262,6 +262,31 @@ Note, there is no need to handle the complexity where the fair price is currentl
 - if the fair price is currently on the lower curve, the best-ask will also be on the lower curve
 - if the fair price is currently on the upper curve, the best-bid will also be on the upper curve
 
+## Curve validity
+
+To prevent the protocol evaluating AMMs providing little liquidity to the network, the network will reject AMM submissions or amendments which cause an AMMs liquidity to be spread too thinly across it's entire range.
+
+If the number of ticks in the largest price range in which the AMM quotes zero volume is more than the parameter $allowedEmptyAmmLevels$, then the submission or amendment will be rejected. Note this parameter is defined on each market to allow different markets with varying volatility to be configured appropriately.
+
+- for the lower curve, this range is between the fair price at which the AMMs long position is $P=1$ and the base price.
+- for the upper curve, this range is between the fair price at which the AMMs short position is $(P_v-1)$ and the upper price bound.
+
+The above definitions yield the following inequality which must be satisfied for both the upper and lower curve (providing they are defined) for the AMM to be valid.
+
+$$
+n\cdot\Delta{p} \geq \frac{L\cdot\sqrt{p_u}}{L + \Delta{P}\cdot \sqrt{p_u}}
+$$
+
+Where:
+
+- $\Delta{p}$ is the smallest price movement supported by the market's price decimals and tick size
+- $\Delta{P}$ is the smallest position size supported by the market's position decimals
+- $n$ is the market parameter $allowedEmptyAmmLevels$
+- $L$ is the liquidity score for the relevant curve
+- $p_u$ is the upper price (the base price for the lower curve and the upper bound for the upper curve)
+
+Note, if the market parameter $allowedEmptyAmmLevels$ is updated via governance all existing pools that would no longer satisfy the inequality **must not** be cancelled. Amends to these pools should be evaluated and rejected if necessary and any cancellations should be accepted.
+
 ## Determining Liquidity Contribution
 
 The provided liquidity from an AMM commitment must be determined for two reasons. Firstly to decide instantaneous distribution of liquidity fees between the various liquidity types and secondly to calculate a virtual liquidity commitment amount for assigning AMM users with an ELS value. This will be used for determining the distribution of ELS-eligible fees on a market along with voting weight in market change proposals.

--- a/protocol/0090-VAMM-automated_market_maker.md
+++ b/protocol/0090-VAMM-automated_market_maker.md
@@ -235,6 +235,33 @@ $$
 
 Then simply return the absolute difference between these two prices.
 
+## Best bid / best ask
+
+As the volume provided between two ticks can theoretically be less than the smallest unit of volume supported by the market's position decimals, the best-bid and ask will not always simply be one tick greater or less than the AMMs current fair price.
+
+Instead the best-bid and best-ask of an AMM curve is defined as the price levels at which the AMM will quote at least one unit of volume between those prices and the current fair price. Re-arranging the formulas defined in the prior [section](#volume-between-two-prices) yields the following:
+
+$$
+p_{bb} = \frac{L\cdot\sqrt{p_f}}{L + \Delta{P}\cdot \sqrt{p_f}}
+$$
+
+$$
+p_{ba} = \frac{L\cdot\sqrt{p_f}}{L - \Delta{P}\cdot \sqrt{p_f}}
+$$
+
+Where:
+
+- $P_{bb}$ is the calculated best bid
+- $P_{ba}$ is the calculated best ask
+- $p_{f}$ is the current fair price as calculated [here](#fair-price)
+- $L$ is the liquidity score for the current curve as calculated [here](#determining-volumes-and-prices)
+- $\Delta{P}$ is the smallest possible position supported by the markets position decimals, i.e. 1 unit of volume.
+
+Note, there is no need to handle the complexity where the fair price is currently on the lower curve but the best ask exists on the upper curve (or visa-versa) as by definition if the party has the smallest possible position $\Delta{P}$, their fair price should be such that between that price and the base price they quote at least $\Delta{P}$. In short:
+
+- if the fair price is currently on the lower curve, the best-ask will also be on the lower curve
+- if the fair price is currently on the upper curve, the best-bid will also be on the upper curve
+
 ## Determining Liquidity Contribution
 
 The provided liquidity from an AMM commitment must be determined for two reasons. Firstly to decide instantaneous distribution of liquidity fees between the various liquidity types and secondly to calculate a virtual liquidity commitment amount for assigning AMM users with an ELS value. This will be used for determining the distribution of ELS-eligible fees on a market along with voting weight in market change proposals.

--- a/protocol/0090-VAMM-automated_market_maker.md
+++ b/protocol/0090-VAMM-automated_market_maker.md
@@ -242,11 +242,11 @@ As the volume provided between two ticks can theoretically be less than the smal
 Instead the best-bid and best-ask of an AMM curve is defined as the price levels at which the AMM will quote at least one unit of volume between those prices and the current fair price. Re-arranging the formulas defined in the prior [section](#volume-between-two-prices) yields the following:
 
 $$
-p_{bb} = (\frac{L\cdot\sqrt{p_f}}{L + \Delta{P}\cdot \sqrt{p_f}})^2
+p_{bb} = \bigg(\frac{L\cdot\sqrt{p_f}}{L + \Delta{P}\cdot \sqrt{p_f}}\bigg)^2
 $$
 
 $$
-p_{ba} = (\frac{L\cdot\sqrt{p_f}}{L - \Delta{P}\cdot \sqrt{p_f}})^2
+p_{ba} = \bigg(\frac{L\cdot\sqrt{p_f}}{L - \Delta{P}\cdot \sqrt{p_f}}\bigg)^2
 $$
 
 Where:


### PR DESCRIPTION
## Summary
Currently core rejects any AMM pool which does not provide at least one unit of volume between every tick in the AMM's range. PR updates spec with a new market parameter $allowedEmptyAmmLevels$ which defines the maximum size of a range in which an AMM is allowed to quote no volume. This range is measured in ticks.

As a guide of what this change means for mainnet markets, the below plot shows the value $allowedEmptyAmmLevels$ should be set to for the smallest commitment to be valid when the specific parameters are selected.

 e.g. to allow $leverageAtLowerBounds=5$ for a $lowerBound$ offset 2% from the $basePrice$, $allowedEmptyAmmLevels\geq1600$

![largest_empty_range](https://github.com/user-attachments/assets/7c680dbc-25e0-4210-a0af-c711ce9e64dd)

The PR also gives equations for calculating the best-bid / best-ask to avoid core iterating over the range to find the price at which an AMM provides at least one unit of volume.

## Notes

- PR also corrects spec inaccuracy where it is stated the curve is recalculated based on the account balances. The curve is in fact fixed based on the commitment size - see commit [f2b856539a24350baec3ad1093f72106e25b6705](https://github.com/vegaprotocol/specs/pull/2358/commits/f2b856539a24350baec3ad1093f72106e25b6705).
- with current core implementation rearranging formulas to allow the AMM estimation API to return the commitment size for required for a specific pool is not trivial, for now it is left as simply returning pool valid / not-valid.
